### PR TITLE
feat(cc): write exec/background commands to file for execution

### DIFF
--- a/src/python/phenix_apps/apps/scorch/cc/cc.py
+++ b/src/python/phenix_apps/apps/scorch/cc/cc.py
@@ -62,12 +62,26 @@ class CC(ComponentBase):
 
                         self.print(f"command '{cmd.args}' executed in VM {vm.hostname} using cc")
 
-                        if results['exitcode']:
+                        node = self.extract_node(vm.hostname)
+
+                        # HACK: If Windows, use presence of stderr to determine
+                        # success/failure instead of exit code. Ugh...
+                        if node.hardware.os_type.lower() == "windows":
+                            if results['stderr']:
+                                self.eprint(f"command '{cmd.args}' resulted in output to STDERR (assuming failure)")
+                                self.print(f"STDERR Output: {results['stderr']}")
+
+                                sys.exit(1)
+                        elif results['exitcode']:
                             self.eprint(f"command '{cmd.args}' returned a non-zero exit code of '{results['exitcode']}'")
+
+                            if results['stderr']:
+                                self.print(f"STDERR Output: {results['stderr']}")
+
                             sys.exit(1)
 
-                        self.print(f"results from '{cmd.args}':")
-                        self.print(results['stdout'])
+                        if results['stdout']:
+                            self.print(f"STDOUT Output: {results['stdout']}")
 
                         if validator:
                             self.print(f"validating results from '{cmd.args}'")

--- a/src/python/phenix_apps/common/utils.py
+++ b/src/python/phenix_apps/common/utils.py
@@ -269,8 +269,18 @@ def mm_exec_wait(mm, vm, cmd, once=True):
         mm.cc_exec(cmd)
 
     last_cmd = mm_last_command(mm)
-
     mm_wait_for_cmd(mm, last_cmd['id'])
+
+    # we only expect a single response since scoped by VM
+    resp = mm.cc_exitcode(last_cmd['id'], vm)[0]
+
+    result = {
+        'id':       last_cmd['id'],
+        'cmd':      last_cmd['cmd'],
+        'exitcode': int(resp['Response']),
+        'stderr':   None,
+        'stdout':   None,
+    }
 
     resps = mm.cc_responses(last_cmd['id'])
     uuid  = mm_vm_uuid(mm, vm)
@@ -284,14 +294,6 @@ def mm_exec_wait(mm, vm, cmd, once=True):
     #   'Error': '',
     #   'Data': None
     # }]
-
-    result = {
-        'id':       last_cmd['id'],
-        'cmd':      last_cmd['cmd'],
-        'stdout':   None,
-        'stderr':   None,
-        'exitcode': None, # TODO: once new minimega Python module is released
-    }
 
     for row in resps:
         if not row['Response']:


### PR DESCRIPTION
To avoid issues with command quoting, piping, and redirects, the Scorch `component` now writes `exec` and `background` args specified in the config to file, sends the file to the target VM, and then uses bash or PowerShell to execute the file on the target VM. This all happens in the background without any additional configuration from the user.

This PR also includes updates to query command exit codes from minimega for `exec` commands for Linux targets and use the presence of STDERR to determine if PowerShell didn't exit correctly for Windows targets.