### PR TITLE
Add dynamic broker option to ot-sim app

### DIFF
--- a/src/python/phenix_apps/apps/otsim/otsim.py
+++ b/src/python/phenix_apps/apps/otsim/otsim.py
@@ -39,10 +39,11 @@ class OTSim(AppBase):
             hostname = broker['hostname']
             iface    = None
 
-          if 'base-fed-count' in broker:
+          if any(key in broker for key in ['base-fed-count', 'dynamic']):
             if hostname not in self.brokers:
               self.brokers[hostname] = {
-                'feds':      int(broker['base-fed-count']),
+                'feds':      broker.get('base-fed-count', 0),
+                'dynamic':   broker.get('dynamic', False),
                 'log-level': broker.get('log-level', 'SUMMARY'),
                 'log-file':  broker.get('log-file', '/var/log/helics-broker.log'),
               }
@@ -280,10 +281,7 @@ class OTSim(AppBase):
       start_file = f'{self.otsim_dir}/{hostname}-helics-broker.sh'
 
       with open(start_file, 'w') as f:
-        utils.mako_serve_template(
-          'helics_broker.mako', templates, f,
-          feds=cfg['feds'], log_level=cfg['log-level'], log_file=cfg['log-file'],
-        )
+        utils.mako_serve_template('helics_broker.mako', templates, f, cfg=cfg)
 
       self.add_inject(hostname=hostname, inject={'src': start_file, 'dst': '/etc/phenix/startup/90-helics-broker.sh'})
 

--- a/src/python/phenix_apps/apps/otsim/templates/helics_broker.mako
+++ b/src/python/phenix_apps/apps/otsim/templates/helics_broker.mako
@@ -1,1 +1,2 @@
-helics_broker -f ${feds} --ipv4 --loglevel ${log_level} --logfile ${log_file} --autorestart &
+<% type = '--dynamic' if cfg['dynamic'] else '-f{}'.format(cfg['feds']) %>\
+helics_broker ${type} --ipv4 --loglevel ${cfg['log-level']} --logfile ${cfg['log-file']} --autorestart &


### PR DESCRIPTION
Adds an option for a key in the ot-sim phenix user app helics broker metadata that when used, will replace the minimum federate arg with `--dynamic`, meaning the broker will allow federates to connect dynamically even after the federation enters initialization mode. The 'dynamic' key (if set to `true`) will override the 'base-fed-count' key if both are included.

This feature was added in the [latest HELICS release](https://github.com/GMLC-TDC/HELICS/releases/tag/v3.4.0).

E.g. scenario.yml:
```yaml
  - name: ot-sim
    metadata:
      helics:
        broker:
          log-level: summary
          hostname: broker|eth0
          dynamic: true
```

The resulting broker command for the above config would be:
```bash
helics_broker --dynamic --ipv4 --loglevel summary --logfile /var/log/helics-broker.log --autorestart &
```