### PR TITLE
Adding flexibility for sceptre app

### DIFF
--- a/src/python/phenix_apps/apps/sceptre/templates/auto_winscp.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/auto_winscp.mako
@@ -1,0 +1,32 @@
+function Phenix-StartupComplete {
+  $key = Get-Item -LiteralPath 'HKLM:\Software\phenix' -ErrorAction SilentlyContinue
+
+  if ($key) {
+    $val = $key.GetValue('startup')
+
+    if ($val) {
+      return $val -eq 'done'
+    }
+
+    return $false
+  }
+
+  return $false
+}
+while (-Not (Phenix-StartupComplete)) {
+    Start-Sleep -s 30
+}
+
+while ($true)
+{
+	Start-Sleep -s ${connect_interval}
+	% for fd in eng_fd:
+	    % for iface in fd.topology.network.interfaces:
+		% if not iface.type == 'serial' and iface.vlan.lower() != 'mgmt':
+$winscp = Start-Process -FilePath "C:\Program Files (x86)\WinSCP\WinSCP.exe" -ArgumentList "/console /open -hostkey=* scp://root:SiaSd3te@${iface.address}" -passthru
+Start-Sleep -s 5
+Stop-Process $winscp.Id
+	       % endif
+	    % endfor
+	% endfor
+}

--- a/src/python/phenix_apps/apps/sceptre/templates/hmi.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/hmi.mako
@@ -38,9 +38,7 @@ Show-Sleep(200)
 Echo ''
 Echo 'Opening MySCADA Interface...'
 % for scada_addr in scada_ips:
-% if scada_addr.split('.')[:-1] == hmi_ip.split('.')[:-1] or len(scada_ips) == 1:
 Start-Process -FilePath "C:\Program Files (x86)\Mozilla Firefox\firefox.exe" -ArgumentList ${scada_addr} -WindowStyle Maximized
-% endif
 % endfor
 Echo 'Done.'
 

--- a/src/python/phenix_apps/apps/sceptre/templates/putty.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/putty.mako
@@ -21,12 +21,12 @@ while (-Not (Phenix-StartupComplete)) {
 new-item -path "HKCU:\Software\SimonTatham\"
 new-item -path "HKCU:\Software\SimonTatham\PuTTY\"
 new-item -path "HKCU:\Software\SimonTatham\PuTTY\Sessions"
-new-item -path "HKCU:\Software\SimonTatham\PuTTY\Sessions\${fd.name}"
-    % for iface in fd.interfaces:
-        % if not iface.type_ == 'serial' and iface.vlan_alias.lower() != 'mgmt':
-new-itemproperty -path "HKCU:\Software\SimonTatham\PuTTY\Sessions\${fd.name}" -name Hostname -value ${iface.ipv4_address}
-new-itemproperty -path "HKCU:\Software\SimonTatham\PuTTY\Sessions\${fd.name}" -name Protocol -value telnet
-new-itemproperty -path "HKCU:\Software\SimonTatham\PuTTY\Sessions\${fd.name}" -name PortNumber -value 1337 -type DWord
+new-item -path "HKCU:\Software\SimonTatham\PuTTY\Sessions\${fd.hostname}"
+    % for iface in fd.topology.network.interfaces:
+        % if not iface.type == 'serial' and iface.vlan.lower() != 'mgmt':
+new-itemproperty -path "HKCU:\Software\SimonTatham\PuTTY\Sessions\${fd.hostname}" -name Hostname -value ${iface.address}
+new-itemproperty -path "HKCU:\Software\SimonTatham\PuTTY\Sessions\${fd.hostname}" -name Protocol -value telnet
+new-itemproperty -path "HKCU:\Software\SimonTatham\PuTTY\Sessions\${fd.hostname}" -name PortNumber -value 1337 -type DWord
 <% break %>
         % endif
     % endfor

--- a/src/python/phenix_apps/apps/sceptre/templates/sceptre_start.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/sceptre_start.mako
@@ -1,6 +1,6 @@
 % if os == 'linux':
     % for interface in ips:
-        % if interface['vlan'] and interface['vlan'].lower() == 'mgmt':
+        % if interface['vlan']:
 echo 'ListenAddress ${interface['address']}' >> /etc/ssh/sshd_config
         % endif
     % endfor


### PR DESCRIPTION
* Added flexibility to specify which field devices and engineering workstation can connect to
* Fixing putty config file for engineering workstation
* Adding `auto_winscp` to autoconnect the engineering workstation to field devices via WinSCP if desires
* Add flexibility to specify which scada server(s) and HMI connects to