### PR TITLE
Check if node exists before appending

### DIFF
--- a/src/python/phenix_apps/apps/__init__.py
+++ b/src/python/phenix_apps/apps/__init__.py
@@ -308,8 +308,22 @@ class AppBase(object):
 
         return None
 
-    def add_node(self, node):
-        self.experiment.spec.topology.nodes.append(node)
+    def add_node(self, new_node, overwrite = False):
+        found = None
+
+        for idx, node in enumerate(self.experiment.spec.topology.nodes):
+            if node.general.hostname == new_node['general']['hostname']:
+                found = idx
+                break
+
+        # If we didn't find an existing node, just append the new node.
+        # If there is an existing node and the overwrite arg is set,
+        # overwrite it with the new node, otherwise do nothing. Check
+        # if found is None since found (idx) could be 0.
+        if found is None:
+            self.experiment.spec.topology.nodes.append(new_node)
+        elif overwrite:
+            self.experiment.spec.topology.nodes[found] = Box(new_node)
 
     def add_annotation(self, hostname, key, value):
         node = self.extract_node(hostname)


### PR DESCRIPTION
Allows overwriting node using the optional `overwrite` parameter.

_**Solves the issue if an app adds a node during the `configure` stage, then a user edits the exp config before starting, the `configure` stage gets ran again on save of the config, so a duplicate node is added **_