### PR TITLE
Alicanto startup script

### DIFF
--- a/src/python/phenix_apps/apps/sceptre/sceptre.py
+++ b/src/python/phenix_apps/apps/sceptre/sceptre.py
@@ -1407,6 +1407,13 @@ class Sceptre(AppBase):
         secondary_historian_ips = {"historian": []}
 
         for historian in historians:
+            historian_ifaces = []
+            for iface in historian.topology.network.interfaces:
+                if iface.vlan != "mgmt":
+                    historian_ifaces.append(iface)
+
+            iface = historian_ifaces[0]
+
             if historian.metadata:
                 if "primary" in historian.metadata and historian.metadata.primary:
                     if historian.metadata.primary not in secondary_historian_ips:

--- a/src/python/phenix_apps/apps/sceptre/templates/sceptre_start.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/sceptre_start.mako
@@ -17,6 +17,8 @@ bennu-simulink-provider --server-endpoint '${server_endpoint}' --publish-endpoin
         % if metadata.get('gt'):
 ./simulinkgt -addr :8080 -file groundTruth.txt -tmpl main.tmpl 2>&1 > /etc/sceptre/log/gt.log &
         % endif
+    % elif metadata.get('simulator','').lower() == 'alicanto':
+pybennu-alicanto -c /etc/sceptre/alicanto.json -d DEBUG
     % elif any(x in name.lower() for x in ['provider', 'helics-provider']) or metadata.get('simulator', '').lower().startswith('powerworld') or metadata.get('simulator', '').lower() == 'pypower':
         % if needsleep:
 sleep 60s


### PR DESCRIPTION
Added Alicanto startup script to `sceptre_start.mako`. Use with metadata 'simulator: Alicanto', `type: provider'. 