### PR TITLE
fix: return mask instead of duplicate address

### DIFF
--- a/src/python/phenix_apps/apps/__init__.py
+++ b/src/python/phenix_apps/apps/__init__.py
@@ -289,7 +289,7 @@ class AppBase(object):
 
             if 'address' in i:
                 if include_mask:
-                    return i['address'], i['address']
+                    return i['address'], i['mask']
                 else:
                     return i['address']
 


### PR DESCRIPTION
Current code is a bug - when `include_mask=True`, the function returns `address, address` instead of the correct `address, mask`