### PR TITLE
Bug fixes and reset_cc

### DIFF
--- a/src/python/phenix_apps/apps/scorch/__init__.py
+++ b/src/python/phenix_apps/apps/scorch/__init__.py
@@ -333,16 +333,16 @@ class ComponentBase(object):
     ) -> bool:
         if os_type == "linux":
             # "ps -e" cuts off full command name, need "f" to get full command
-            ps_list = self.run_and_check_command(vm, "ps -ef", timeout=5.0, poll_rate=0.5)["stdout"]
+            ps_list = self.run_and_check_command(vm, "ps -ef", timeout=15.0, poll_rate=0.5)["stdout"]
         elif os_type == "windows":
-            ps_list = self.run_and_check_command(vm, "tasklist", timeout=7.0, poll_rate=0.5)["stdout"]
+            ps_list = self.run_and_check_command(vm, "tasklist", timeout=15.0, poll_rate=0.5)["stdout"]
         else:
             raise ValueError(f"unknown os_type '{os_type}' for VM {vm}")
 
         if process.lower() in ps_list.lower():
             return True
         else:
-            self.eprint(f"process {process} is not running on {vm}")
+            self.eprint(f"process '{process}' is not running on '{vm}'")
             return False
 
     def configure(self):

--- a/src/python/phenix_apps/apps/scorch/mm/README.md
+++ b/src/python/phenix_apps/apps/scorch/mm/README.md
@@ -7,45 +7,48 @@ exe:  phenix-scorch-component-mm
 
 ## Metadata Options
 
-```
+```yaml
 metadata:
+  # Commands (types) to run for a particular stage (configure, start, stop, cleanup)
   configure:
-  - type: start_capture
-    capture:
-      bridge: phenix
-      filename: capture.pcap # will be auto generated as <bridge>-<ts>.pcap if not provided
-      filter: port 80 # typical BPF filter expression
-      snaplen: null
-  - type: stop_capture
-    capture:
-      bridge: phenix
-      convert: true # convert to JSON (for parsing into Elastic, for example) (default is false)
+    - type: start_capture
+      capture:
+        bridge: phenix
+        filename: capture.pcap # will be auto generated as <bridge>-<ts>.pcap if not provided
+        filter: port 80 # typical BPF filter expression
+        snaplen: null
+    - type: stop_capture
+      capture:
+        bridge: phenix
+        convert: true # convert to JSON (for parsing into Elastic, for example) (default is false)
   start: [] # same array of keys as above
   stop: [] # same array of keys as above
   cleanup: [] # same array of keys as above
+
+  # Commands (types) to run for specific VMs, for a particular stage
   vms:
-  - hostname: <string>
-    configure:
-    - type: start # can be start, stop, connect, disconnect, start_capture, stop_capture
-    - type: stop
-    - type: connect # can also be used to move an already connected interface
-      connect:
-        interface: 0 # index of interface
-        vlan: FOO
-        bridge: phenix # will use the same bridge previously connected to (if moving) if not provided
-    - type: disconnect
-      disconnect:
-        interface: 0 # index of interface
-    - type: start_capture
-      capture:
-        interface: 0
-        filename: capture.pcap # will be auto generated as <host>-<iface>-<ts>.pcap if not provided
-        filter: port 80 # typical BPF filter expression
-        snaplen: null
-    - type: stop_capture # will stop captures on all interfaces (minimega limitation)
-      capture:
-        convert: true # convert to JSON (for parsing into Elastic, for example) (default is false)
-    start: [] # same array of keys as above
-    stop: [] # same array of keys as above
-    cleanup: [] # same array of keys as above
+    - hostname: <string>
+      configure:
+      - type: start # can be start, stop, connect, disconnect, start_capture, stop_capture
+      - type: stop
+      - type: connect # can also be used to move an already connected interface
+        connect:
+          interface: 0 # index of interface
+          vlan: FOO
+          bridge: phenix # will use the same bridge previously connected to (if moving) if not provided
+      - type: disconnect
+        disconnect:
+          interface: 0 # index of interface
+      - type: start_capture
+        capture:
+          interface: 0
+          filename: capture.pcap # will be auto generated as <host>-<iface>-<ts>.pcap if not provided
+          filter: port 80 # typical BPF filter expression
+          snaplen: null
+      - type: stop_capture # will stop captures on all interfaces (minimega limitation)
+        capture:
+          convert: true # convert to JSON (for parsing into Elastic, for example) (default is false)
+      start: [] # same array of keys as above
+      stop: [] # same array of keys as above
+      cleanup: [] # same array of keys as above
 ```

--- a/src/python/phenix_apps/apps/scorch/mm/mm.py
+++ b/src/python/phenix_apps/apps/scorch/mm/mm.py
@@ -14,24 +14,19 @@ class MM(ComponentBase):
 
         self.execute_stage()
 
-
     def configure(self):
         self.__run('configure')
-
 
     def start(self):
         self.__run('start')
 
-
     def stop(self):
         self.__run('stop')
-
 
     def cleanup(self):
         self.__run('cleanup')
 
-
-    def __run(self, stage):
+    def __run(self, stage: str) -> None:
         mm = self.mm_init()
 
         commands = self.metadata.get(stage, [])
@@ -83,13 +78,13 @@ class MM(ComponentBase):
                 cap = cmd.get('capture', None)
 
                 if not cap:
-                    self.eprint(f'no bridge capture details provided')
+                    self.eprint('no bridge capture details provided')
                     sys.exit(1)
 
                 bridge = cap.get('bridge', None)
 
                 if not bridge:
-                    self.eprint(f'bridge to stop capture traffic on not provided')
+                    self.eprint('bridge to stop capture traffic on not provided')
                     sys.exit(1)
                 try:
                     self.print(f'stopping pcap capture on bridge {bridge}')
@@ -132,6 +127,8 @@ class MM(ComponentBase):
                 except Exception as ex:
                     self.eprint(f'unable to stop pcap capture on bridge {bridge}: {ex}')
                     sys.exit(1)
+            else:
+                self.eprint(f"Unknown command type '{cmd.type}'")
 
         vms = self.metadata.get('vms', [])
 
@@ -285,6 +282,8 @@ class MM(ComponentBase):
                     except Exception as ex:
                         self.eprint(f'unable to stop pcap capture(s) on vm {vm.hostname}: {ex}')
                         sys.exit(1)
+                else:
+                    self.eprint(f"Unknown command type for VM '{vm.hostname}': {cmd.type}")
 
 
 def main():

--- a/src/python/phenix_apps/common/utils.py
+++ b/src/python/phenix_apps/common/utils.py
@@ -242,7 +242,7 @@ def mm_send(mm: minimega.minimega, vm: str, src: str, dst: str) -> None:
                 os.makedirs(dst_dir)
 
             if os.path.isdir(src):
-                shutil.copytree(src, vm_dst)
+                shutil.copytree(src, vm_dst, dirs_exist_ok=True)
             else:
                 shutil.copyfile(src, vm_dst)
         finally:


### PR DESCRIPTION
- Fix process list commands timing out in some cases by raising the timeout
- Fix issues with mm_send when destination directories already exist
- Add "reset_cc" command to "mm" scorch component. This really shouldn't be needed, but there are so many weird state issues with miniccc commands and responses that this is unfortunately needed. We've been doing this manually, with random shell scripts, or by dumping them in random components (see `rtds` component) that it makes sense to just add it as a proper thing in the pipeline.