### PR TITLE
fix(scorch-disruption): patch params in call to _run_physical_disruption

### DIFF
--- a/src/python/phenix_apps/apps/scorch/disruption/disruption.py
+++ b/src/python/phenix_apps/apps/scorch/disruption/disruption.py
@@ -187,7 +187,7 @@ class Disruption(ComponentBase):
             sleep(physical_start_delay)
 
             # physical duration
-            elapsed = self._run_physical_disruption(physical_start_delay)
+            elapsed = self._run_physical_disruption()
 
             # sleep until experiment run_duration time is up, physical ended early
             remaining = run_duration - elapsed - physical_start_delay


### PR DESCRIPTION
Bugfix: Squash bug in scorch component "disruption". 

During physical disruption, call to function "_run_physical_disruption" was incorrectly parameterized, causing component to break. Fix removes extraneous parameter.   