### PR TITLE
feat: add opalrt infrastructure

### DIFF
--- a/src/python/phenix_apps/apps/sceptre/configs/configs.py
+++ b/src/python/phenix_apps/apps/sceptre/configs/configs.py
@@ -15,6 +15,8 @@ def get_fdconfig_class(infrastructure: str) -> type:
         base_class = infra.FuelInfrastructure
     elif infrastructure == 'rtds':
         base_class = infra.RTDSInfrastructure
+    elif infrastructure == 'opalrt':
+        base_class = infra.OPALRTInfrastructure
     elif infrastructure == 'waterway':
         base_class = infra.WaterwayInfrastructure
     elif infrastructure == 'battery':

--- a/src/python/phenix_apps/apps/sceptre/configs/configs.py
+++ b/src/python/phenix_apps/apps/sceptre/configs/configs.py
@@ -3,6 +3,9 @@ import phenix_apps.apps.sceptre.configs.infrastructures as infra
 
 
 def get_fdconfig_class(infrastructure: str) -> type:
+    # no reason for this to be case-sensitive
+    infrastructure = infrastructure.lower().strip()
+
     if infrastructure == 'power-transmission':
         base_class = infra.PowerTransmissionInfrastructure
     elif infrastructure == 'power-distribution':

--- a/src/python/phenix_apps/apps/sceptre/configs/infrastructures.py
+++ b/src/python/phenix_apps/apps/sceptre/configs/infrastructures.py
@@ -416,6 +416,42 @@ class FuelInfrastructure(Infrastructure):
                       infrastructure=infra, **device_kwargs)
 
 
+class OPALRTInfrastructure(Infrastructure):
+    """OPALRT infrastructure for the OPALRT dynamic simulator."""
+
+    def __init__(self):
+        super().__init__()
+        super().register('opalrt')
+        self.range = -32767.0, 32767.0
+
+    @staticmethod
+    def create_device(device_type, device_name, protocol, reg_config, **kwargs):
+        if type(device_type) == str and device_type.lower() == 'analog-read':
+            device_kwargs = {
+                'range': (-32767.0, 32767.0),
+                'analog-read': kwargs.get('analog-read', ['value']),
+            }
+            return Device(device_type, device_name, protocol, reg_config, **device_kwargs)
+        elif type(device_type) == str and device_type.lower() == 'analog-read-write':
+            device_kwargs = {
+                'range': (-32767.0, 32767.0),
+                'analog-read-write': kwargs.get('analog-read-write', ['value']),
+            }
+            return Device(device_type, device_name, protocol, reg_config, **device_kwargs)
+        elif type(device_type) == str and device_type.lower() == 'binary-read':
+            device_kwargs = {
+                'range': (0, 1000),
+                'binary-read': kwargs.get('binary-read', ['value']),
+            }
+            return Device(device_type, device_name, protocol, reg_config, **device_kwargs)
+        elif type(device_type) == str and device_type.lower() == 'binary-read-write':
+            device_kwargs = {
+                'range': (0, 1000),
+                'binary-read-write': kwargs.get('binary-read-write', ['value']),
+            }
+            return Device(device_type, device_name, protocol, reg_config, **device_kwargs)
+
+
 class RTDSInfrastructure(Infrastructure):
     """Real-Time Dynamic Simulator (RTDS) infrastructure."""
     def __init__(self):


### PR DESCRIPTION
Add infrastructure for the (forthcoming) OPALRT provider. Additionally, use case-insensitive comparison when looking up infrastructure classes, to be a little nicer to users who might accidentally capitalize when writing configs.