### PR TITLE
Ot sim updates with configurable HELICS end time and DNP3 Scan Rate

### DIFF
--- a/src/python/phenix_apps/apps/otsim/device.py
+++ b/src/python/phenix_apps/apps/otsim/device.py
@@ -13,18 +13,19 @@ class Register:
 
 
 class Device:
-  def __init__(self, node, default_infra = 'power-distribution'):
+  def __init__(self, node, configs = {}, default_infra = 'power-distribution'):
     self.node  = node
     self.md    = node.get('metadata', {})
     self.infra = self.md.get('infrastructure', default_infra)
 
     self.registers = {}
     self.processed = False
+    self.configs = configs
 
 
 class FEP(Device):
-  def __init__(self, node):
-    Device.__init__(self, node)
+  def __init__(self, node, configs = {}):
+    Device.__init__(self, node, configs)
 
   def process(self, devices):
     if self.processed: return
@@ -72,7 +73,9 @@ class FEP(Device):
       if 'dnp3' in device.registers:
         client = DNP3()
         client.init_xml_root('client', device.node)
-        client.init_master_xml()
+        if 'scan-rate' in self.configs.keys():
+          client.init_master_xml(self.configs['scan-rate'])
+
         client.registers_to_xml(device.registers['dnp3'])
 
         config.append_to_root(client.root)
@@ -220,8 +223,8 @@ class FieldDeviceServer(Device):
 
 
 class FieldDeviceClient(Device):
-  def __init__(self, node):
-    Device.__init__(self, node)
+  def __init__(self, node, configs = {}):
+    Device.__init__(self, node, configs)
 
   def process(self, devices):
     if self.processed: return
@@ -251,7 +254,9 @@ class FieldDeviceClient(Device):
       if 'dnp3' in device.registers:
         client = DNP3()
         client.init_xml_root('client', device.node)
-        client.init_master_xml()
+        if 'scan-rate' in self.configs.keys(): 
+          client.init_master_xml(self.configs['scan-rate'])
+          
         client.registers_to_xml(device.registers['dnp3'])
 
         config.append_to_root(client.root)

--- a/src/python/phenix_apps/apps/otsim/otsim.py
+++ b/src/python/phenix_apps/apps/otsim/otsim.py
@@ -100,9 +100,13 @@ class OTSim(AppBase):
       # handle `self.default_endpoint` being set to False
       if self.default_endpoint and '/' not in self.default_endpoint:
         self.default_endpoint = f'{self.default_fed}/{self.default_endpoint}'
+      
+      self.end_time = str(self.metadata['helics'].get('end-time', 36000))
+
     else:
       self.default_fed      = 'OpenDSS'
       self.default_endpoint = 'OpenDSS/updates'
+      self.end_time = str(36000)
 
 
   def pre_start(self):
@@ -175,6 +179,9 @@ class OTSim(AppBase):
         broker    = ET.SubElement(io, 'broker-endpoint')
         federate  = ET.SubElement(io, 'federate-name')
         log_level = ET.SubElement(io, 'federate-log-level')
+        end_time  = ET.SubElement(io, 'end-time')
+        
+        end_time.text = self.end_time
 
         if 'helics' in md:
           if 'broker' in md['helics']:
@@ -195,14 +202,15 @@ class OTSim(AppBase):
           else:
             federate.text  = server.hostname
             log_level.text = 'SUMMARY'
+
         else:
           addr = self.__process_helics_broker_metadata(self.metadata)
           assert addr
-
+          
           broker.text    = addr
           federate.text  = server.hostname
           log_level.text = 'SUMMARY'
-
+        
         infrastructure.io_module_xml(io, infra, devices)
 
         config.append_to_root(io)

--- a/src/python/phenix_apps/apps/otsim/otsim.py
+++ b/src/python/phenix_apps/apps/otsim/otsim.py
@@ -75,6 +75,15 @@ class OTSim(AppBase):
         elif 'address' in broker:
           return broker['address']
 
+  def __process_scan_rate_metadata(self, md):
+    if 'helics' in md:
+      if 'scan-rate' in md['helics']:
+        return md['helics']['scan-rate']
+      else:
+        return 5
+    else:
+      return None
+    
 
   def __init_defaults(self):
     self.default_infrastructure = self.metadata.get('infrastructure', 'power-distribution')
@@ -228,9 +237,14 @@ class OTSim(AppBase):
 
     # Preload all the FEPs so they can force downstream FEPs to process their
     # configs during their own processing.
-    for fep in feps:
-      ot_devices[fep.hostname] = FEP(fep)
+    scan_rate_from_md = self.__process_scan_rate_metadata(self.metadata)
 
+    for fep in feps:
+      if scan_rate_from_md is not None: 
+        ot_devices[fep.hostname] = FEP(fep, {"scan-rate": scan_rate_from_md})
+      else: 
+        ot_devices[fep.hostname] = FEP(fep)
+       
     for fep in feps:
       config  = Config(self.metadata)
       injects = config.init_xml_root(fep.metadata)

--- a/src/python/phenix_apps/apps/otsim/protocols/dnp3.py
+++ b/src/python/phenix_apps/apps/otsim/protocols/dnp3.py
@@ -51,7 +51,7 @@ class DNP3(Protocol):
     endpoint.text = f'{ip}:{port}'
 
 
-  def init_master_xml(self, name='dnp3-master'):
+  def init_master_xml(self, scan_rate_value, name='dnp3-master'):
     self.master = ET.SubElement(self.root, 'master', {'name': name})
 
     local = ET.SubElement(self.master, 'local-address')
@@ -61,7 +61,7 @@ class DNP3(Protocol):
     remote.text = str(1024)
 
     scan_rate = ET.SubElement(self.master, 'scan-rate')
-    scan_rate.text = str(5)
+    scan_rate.text = str(scan_rate_value)
 
 
   def init_outstation_xml(self, name='dnp3-outstation'):


### PR DESCRIPTION
# OT-sim updates

## Description
The changes are primarily for configuring the HELICs end time and customizing scan rate for the DNP3 master

## Related Issue
If applicable, please link to the issue here (e.g., #123).

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Though the DNP3 scan-rate can be part of DNP3 instead of HELICS app, but that can be done in another iteration. Right now the scan-rate is kept as a global property for all the DNP3 RTUs.
