### PR TITLE
fix: provider config missing config-file for RTDS/OPALRT

### DIFF
--- a/src/python/phenix_apps/apps/sceptre/templates/provider_config.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/provider_config.mako
@@ -1,11 +1,13 @@
+<%page args="solver, server_endpoint, publish_endpoint, debug='False', config_helics=None, case_file=None, oneline_file=None, pwds_endpoint=None, config_file=None, **kwargs"/>
 [power-solver-service]
 solver-type       = ${solver}
+debug             = ${debug}
 % if config_helics:
 config-file       = ${config_helics}
 % endif
 % if solver != 'PowerWorldHelics':
-publish-endpoint  = ${publish_endpoint}
 server-endpoint   = ${server_endpoint}
+publish-endpoint  = ${publish_endpoint}
 % endif
 % if solver == 'PowerWorld':
 noise             = normal
@@ -24,4 +26,6 @@ objects-file      = /etc/sceptre/objects.txt
 % elif solver in ['OpenDSS', 'PyPower']:
 case-file         = /etc/sceptre/${case_file}
 % endif
-debug             = true
+% if solver in ['RTDS', 'OPALRT'] or config_file:
+config-file       = ${config_file}
+% endif


### PR DESCRIPTION
# fix: provider config missing config-file for RTDS/OPALRT

## Description
In the previous PR #53 , I missed a critical change to the template for the provider `config.ini`. This PR includes that change, notably the addition of the `config-file` parameter to `config.ini` for RTDS and OPALRT simulators.

This code has been tested in several environments.

## Related Issue
#53 

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
None.
