### PR TITLE
wait script, helics web api

### DIFF
--- a/src/python/phenix_apps/apps/otsim/templates/helics_broker.mako
+++ b/src/python/phenix_apps/apps/otsim/templates/helics_broker.mako
@@ -1,2 +1,2 @@
 <% type = '--dynamic' if cfg['dynamic'] else '-f{}'.format(cfg['feds']) %>\
-helics_broker ${type} --ipv4 --loglevel ${cfg['log-level']} --logfile ${cfg['log-file']} --autorestart &
+helics_broker ${type} --ipv4 --web --http_server_args="--http_port=8080 --external" --loglevel ${cfg['log-level']} --logfile ${cfg['log-file']} --autorestart &

--- a/src/python/phenix_apps/apps/otsim/templates/wait_broker.mako
+++ b/src/python/phenix_apps/apps/otsim/templates/wait_broker.mako
@@ -1,0 +1,5 @@
+#!/bin/bash
+printf "%s" "waiting for root broker"
+time while ! ping -c 1 -n -w 1  ${rootbroker_ip} &> /dev/null; do 
+    printf "%c" "."
+done


### PR DESCRIPTION
# Broker wait script, Helics web api

## Description
Added the wait for broker script, and added the Helics web api for broker argument when otsim app is in charge of generating the broker script.

## Related Issue
[Helics Web API](https://github.com/sandialabs/sceptre-phenix-apps/pull/67)
[Broker wait script](https://github.com/sandialabs/sceptre-phenix-apps/pull/70)

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [ ] Documentation update
- [X] Other (please describe): Results in same behavior of Helics broker whether Helics or otsim app does the work

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
