### PR TITLE
Added feature to parse logic and add internal vars to fd_server and fep

### DIFF
--- a/src/python/phenix_apps/apps/sceptre/app.py
+++ b/src/python/phenix_apps/apps/sceptre/app.py
@@ -872,6 +872,27 @@ class Sceptre(AppBase):
             fd_configs.append(fd_config)
             fd_server_configs[fd_.hostname] = fd_config
 
+            # Gather internal tags that might be defined in logic
+            internal_tags = {}
+
+            output_name_to_tag = {}
+            for protocol in fd_config.protocols:
+                for device in protocol.devices:
+                    for register in device.registers:
+                        input_regs = ['analog-input', 'binary-input', 'input-register', 'discrete-input']
+                        if register.regtype not in input_regs:
+                            io_name = f"{fd_config.name}_O{register.addr}"
+                            output_name_to_tag[f"{register.devname}.{register.field}"] = f"var_{io_name}"
+
+            lines = [line.strip() for line in fd_logic.split(';') if line.strip()]
+            for line in lines:
+                parts = line.split('=', 1)
+                if len(parts) == 2:
+                    lhs = parts[0].strip()
+                    mapped_lhs = output_name_to_tag.get(lhs, None)
+                    if mapped_lhs is None:
+                        internal_tags[lhs] = 0.0
+
             # Write fd server config file injection
             config_file = f"{fd_directory}/config.xml"
 
@@ -900,6 +921,7 @@ class Sceptre(AppBase):
                     fd_config=fd_config,
                     logic=fd_logic,
                     cycle_time=fd_cycle_time,
+                    internal_tags=internal_tags,
                 )
 
             self.render_sceptre_start(
@@ -1212,6 +1234,29 @@ class Sceptre(AppBase):
             InfrastructureFieldDeviceConfig = configs.get_fdconfig_class(
                 fd_.metadata.infrastructure
             )
+            
+            # Gather internal tags that might be defined in logic
+            internal_tags = {}
+
+            output_name_to_tag = {}
+            for protocol in fd_config.protocols:
+                for device in protocol.devices:
+                    for register in device.registers:
+                        input_regs = ['analog-input', 'binary-input', 'input-register', 'discrete-input']
+                        if register.regtype not in input_regs:
+                            io_name = f"{fd_config.name}_O{register.addr}"
+                            output_name_to_tag[f"{register.devname}.{register.field}"] = f"var_{io_name}"
+
+            lines = [line.strip() for line in fd_logic.split(';') if line.strip()]
+            for line in lines:
+                parts = line.split('=', 1)
+                if len(parts) == 2:
+                    lhs = parts[0].strip()
+                    mapped_lhs = output_name_to_tag.get(lhs, None)
+                    if mapped_lhs is None:
+                        internal_tags[lhs] = 0.0
+
+
 
             # instantiate the FieldDeviceConfig class
             fep_config = InfrastructureFieldDeviceConfig(
@@ -1223,6 +1268,7 @@ class Sceptre(AppBase):
                 server_endpoint=srv_endpoint,
                 reg_config=reg_config,
                 counter=fep_counter,
+                internal_tags=internal_tags,
             )
             fd_server_configs[fep_config.name] = fep_config
 

--- a/src/python/phenix_apps/apps/sceptre/templates/fd_server.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/fd_server.mako
@@ -36,6 +36,15 @@ def intercambio(dictionary, string):
         % endfor
     % endfor
 % endfor
+% if internal_tags:
+    % for tag, value in internal_tags.items():
+	    
+	    <internal-tag>
+                <name>${tag}</name>
+                <value>${value}</value>
+	    </internal-tag>
+    % endfor
+% endif
         </tags>
         <comms>
 % for protocol in fd_config.protocols:

--- a/src/python/phenix_apps/apps/sceptre/templates/fep_template.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/fep_template.mako
@@ -85,7 +85,16 @@ sunspec_register = ''
         % endfor
     % endfor
 % endfor
-        </tags>
+if internal_tags:
+    % for tag, value in internal_tags.items():
+
+            <internal-tag>
+                <name>${tag}</name>
+                <value>${value}</value>
+            </internal-tag>
+    % endfor
+% endif
+	</tags>
 
     <comms>
 ################################# CLIENT ########################################


### PR DESCRIPTION

# Added feature to parse logic and add internal vars to fd_server and fep

## Description
The SCEPTRE app will now parse logic and for any intermediate variables that are for inputs or outputs, it will create an internal variable and add to the field device config. 

## Related Issue
NA

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
NA