### PR TITLE
fix(mm): add additional checks and safety

### DIFF
--- a/src/python/app_migration_guide.md
+++ b/src/python/app_migration_guide.md
@@ -21,15 +21,19 @@ import argparse
 import sys
 from .app import MyApp
 
+
 def main():
     parser = argparse.ArgumentParser(description="phenix user app: my-app")
-    parser.add_argument("stage", choices=["configure", "pre-start", ...], help="Lifecycle stage")
+    parser.add_argument(
+        "stage", choices=["configure", "pre-start", ...], help="Lifecycle stage"
+    )
     parser.add_argument("--dry-run", action="store_true", help="Perform a dry run")
     args = parser.parse_args()
 
     app = MyApp(args.stage, args.dry_run)
     app.execute_stage()
     print(app.experiment.to_json())
+
 
 if __name__ == "__main__":
     main()
@@ -43,8 +47,10 @@ Update the file to call the new `AppBase.main()` class method, passing the app's
 # new __main__.py
 from .app import MyApp
 
+
 def main():
     MyApp.main("my-app-name")
+
 
 if __name__ == "__main__":
     main()
@@ -64,6 +70,7 @@ import sys
 from box import Box
 from phenix_apps.apps import AppBase
 
+
 class MyApp(AppBase):
     def __init__(self, stage, dryrun=False):
         self.raw_input = sys.stdin.read()
@@ -80,6 +87,7 @@ The new constructor is much cleaner. It accepts `name`, `stage`, and `dryrun` an
 ```python
 # new app.py
 from phenix_apps.apps import AppBase
+
 
 class MyApp(AppBase):
     def __init__(self, name, stage, dryrun=False):

--- a/src/python/phenix_apps/apps/__init__.py
+++ b/src/python/phenix_apps/apps/__init__.py
@@ -139,6 +139,7 @@ class AppBase:
 
         if wildcard:
             return extracted
+
         return None
 
     def extract_topology_nodes_by_attribute(

--- a/src/python/phenix_apps/apps/scale/README.md
+++ b/src/python/phenix_apps/apps/scale/README.md
@@ -241,6 +241,7 @@ External plugins allow you to extend the Scale app without modifying the core co
 from phenix_apps.apps.scale.interface import ScalePlugin
 from phenix_apps.apps.scale.registry import register_plugin
 
+
 @register_plugin("my-external-plugin")
 class MyExternalPlugin(ScalePlugin):
     # ... implement abstract methods ...

--- a/src/python/phenix_apps/apps/scorch/caldera/caldera.py
+++ b/src/python/phenix_apps/apps/scorch/caldera/caldera.py
@@ -72,9 +72,7 @@ class Caldera(ComponentBase):
                     "api_call.mako", templates, f, model="adversaries"
                 )
 
-            mm.cc_filter(f"name={server}")
-            cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
-            utils.mm_wait_for_cmd(mm, cmd_id)
+            utils.mm_cc_send_wait(mm, server, cmd_src, self.exp_name)
 
             os.remove(cmd_src)
 
@@ -111,9 +109,7 @@ class Caldera(ComponentBase):
                     "api_call.mako", templates, f, model="sources"
                 )
 
-            mm.cc_filter(f"name={server}")
-            cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
-            utils.mm_wait_for_cmd(mm, cmd_id)
+            utils.mm_cc_send_wait(mm, server, cmd_src, self.exp_name)
 
             os.remove(cmd_src)
 
@@ -150,9 +146,7 @@ class Caldera(ComponentBase):
                     "api_call.mako", templates, f, model="planners"
                 )
 
-            mm.cc_filter(f"name={server}")
-            cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
-            utils.mm_wait_for_cmd(mm, cmd_id)
+            utils.mm_cc_send_wait(mm, server, cmd_src, self.exp_name)
 
             os.remove(cmd_src)
 
@@ -183,9 +177,7 @@ class Caldera(ComponentBase):
         with open(cmd_src, "w") as f:
             utils.mako_serve_template("new_operation.mako", templates, f, op=op)
 
-        mm.cc_filter(f"name={server}")
-        cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
-        utils.mm_wait_for_cmd(mm, cmd_id)
+        utils.mm_cc_send_wait(mm, server, cmd_src, self.exp_name)
 
         os.remove(cmd_src)
 
@@ -208,9 +200,7 @@ class Caldera(ComponentBase):
                     "get_operation.mako", templates, f, op=op["id"]
                 )
 
-            mm.cc_filter(f"name={server}")
-            cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
-            utils.mm_wait_for_cmd(mm, cmd_id)
+            utils.mm_cc_send_wait(mm, server, cmd_src, self.exp_name)
 
             os.remove(cmd_src)
 
@@ -236,9 +226,7 @@ class Caldera(ComponentBase):
                 "get_operation_report.mako", templates, f, op=op["id"]
             )
 
-        mm.cc_filter(f"name={server}")
-        cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
-        utils.mm_wait_for_cmd(mm, cmd_id)
+        utils.mm_cc_send_wait(mm, server, cmd_src, self.exp_name)
 
         os.remove(cmd_src)
 

--- a/src/python/phenix_apps/apps/scorch/cc/cc.py
+++ b/src/python/phenix_apps/apps/scorch/cc/cc.py
@@ -138,7 +138,7 @@ class CC(ComponentBase):
                                 raise RuntimeError("results validation failed")
                             logger.info("results are valid")
                     else:
-                        self.mm.cc_filter(f"name={vm.hostname}")
+                        utils.mm_cc_filter_vm(self.mm, vm.hostname)
 
                         if once:
                             self.mm.cc_exec_once(script)
@@ -157,7 +157,7 @@ class CC(ComponentBase):
 
                     script = self.__send_cmd_as_file(vm.hostname, cmd.args)
 
-                    self.mm.cc_filter(f"name={vm.hostname}")
+                    utils.mm_cc_filter_vm(self.mm, vm.hostname)
 
                     if once:
                         self.mm.cc_background_once(script)
@@ -251,9 +251,7 @@ class CC(ComponentBase):
         with open(cmd_src, "w") as f:
             f.write(cmd)
 
-        self.mm.cc_filter(f"name={hostname}")
-        cmd_id = utils.mm_command_id(self.mm.cc_send(cmd_src))
-        utils.mm_wait_for_cmd(self.mm, cmd_id)
+        utils.mm_cc_send_wait(self.mm, hostname, cmd_src, self.exp_name)
         self.mm.clear_cc_filter()
 
         os.remove(cmd_src)

--- a/src/python/phenix_apps/common/settings.py
+++ b/src/python/phenix_apps/common/settings.py
@@ -17,3 +17,25 @@ MM_FILEPATH = os.getenv("MM_FILEPATH", "/phenix/images")
 
 # Base minimega filepath
 MM_SOCKET_PATH = os.getenv("MM_SOCKET_PATH", "/tmp/minimega/minimega")
+
+# Seconds between cc client/command polls
+CC_POLL_RATE = float(os.getenv("PHENIX_CC_POLL_RATE", 2.0))
+
+# Seconds between client-liveness checks during an unbounded cc wait
+CC_LIVENESS_INTERVAL = float(os.getenv("PHENIX_CC_LIVENESS_INTERVAL", 10.0))
+
+# Seconds to wait for a cc exit code after the response is counted
+CC_EXITCODE_GRACE = float(os.getenv("PHENIX_CC_EXITCODE_GRACE", 10.0))
+
+# Seconds to wait for a miniccc client to register
+CC_CLIENT_GRACE = float(os.getenv("PHENIX_CC_CLIENT_GRACE", 300.0))
+
+# Seconds to wait for a cc file send or component start to be acknowledged
+CC_SEND_GRACE = float(os.getenv("PHENIX_CC_SEND_GRACE", 300.0))
+
+# Seconds to wait for a cc command response. 0 == unbounded
+CC_CMD_GRACE = float(os.getenv("PHENIX_CC_CMD_GRACE", 0.0))
+
+# Seconds before the first "still waiting" log line, doubling up to the max
+CC_LOG_INTERVAL = float(os.getenv("PHENIX_CC_LOG_INTERVAL", 10.0))
+CC_LOG_MAX_INTERVAL = float(os.getenv("PHENIX_CC_LOG_MAX_INTERVAL", 320.0))

--- a/src/python/phenix_apps/common/tests/test_utils.py
+++ b/src/python/phenix_apps/common/tests/test_utils.py
@@ -1,39 +1,128 @@
 import minimega
 import pytest
 
-from phenix_apps.common import utils
+from phenix_apps.common import settings, utils
+
+
+class _FakeClock:
+    """Simulated clock: ``sleep`` advances time instead of blocking."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _install_fake_clock(monkeypatch) -> _FakeClock:
+    """Patch ``utils.time`` with a shared ``_FakeClock`` and return it."""
+    clock = _FakeClock()
+    monkeypatch.setattr(utils.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(utils.time, "sleep", clock.sleep)
+
+    return clock
 
 
 class _StubMM:
-    """Stand-in for minimega.minimega whose cc_* methods replay per-call effects:
-    a list (the per-host rows that cc fan-out returns) is returned, an Exception
-    is raised (a transport-level failure). Mirrors _raise_errors so
-    mm_cc_all_hosts can toggle it."""
+    """Stand-in for minimega.minimega.
 
-    def __init__(self, effects=None, client_effects=None):
+    Effect lists are replayed per call; the last entry sticks so a wait can run
+    for hundreds of polls. Rows carrying an ``Error`` raise only while
+    ``_raise_errors`` is set.
+    """
+
+    def __init__(
+        self,
+        effects=None,
+        client_effects=None,
+        vm_info_rows=None,
+        cc_commands_rows=None,
+        cc_commands_effects=None,
+    ):
         self._effects = list(effects or [])
         self._client_effects = list(client_effects or [])
+        self._vm_info_rows = vm_info_rows or []
+        self._cc_commands_rows = cc_commands_rows or []
+        self._cc_commands_effects = (
+            list(cc_commands_effects) if cc_commands_effects is not None else None
+        )
         self._raise_errors = True
         self.calls = 0
         self.client_calls = 0
+        self.vm_info_calls = 0
+        self.vm_info_kwargs = None
+        self.cc_commands_calls = 0
+
+    def _replay(self, effects):
+        # Once down to the last entry, peek instead of popping so it replays
+        # indefinitely rather than raising IndexError on the next call.
+        effect = effects[0] if len(effects) == 1 else effects.pop(0)
+
+        # An Exception effect models a transport/namespace failure, which the
+        # binding raises whether or not per-host errors are being raised.
+        if isinstance(effect, Exception):
+            raise effect
+
+        if self._raise_errors:
+            for row in effect:
+                if row.get("Error"):
+                    raise minimega.Error(row["Error"])
+
+        return effect
 
     def cc_exitcode(self, *_args):
         self.calls += 1
-        effect = self._effects.pop(0)
 
-        if isinstance(effect, Exception):
-            raise effect
-
-        return effect
+        return self._replay(self._effects)
 
     def cc_clients(self, *_args):
         self.client_calls += 1
-        effect = self._client_effects.pop(0)
 
-        if isinstance(effect, Exception):
-            raise effect
+        return self._replay(self._client_effects)
 
-        return effect
+    def cc_commands(self, *_args):
+        self.cc_commands_calls += 1
+
+        if self._cc_commands_effects is not None:
+            return self._replay(self._cc_commands_effects)
+
+        return self._cc_commands_rows
+
+    def vm_info(self, **kwargs):
+        self.vm_info_calls += 1
+        self.vm_info_kwargs = kwargs
+
+        return self._vm_info_rows
+
+
+def _vm_info_row(name, uuid, host="gibson1336"):
+    """One `vm info summary` per-host row. Columns are read from Header, not
+    fixed offsets -- this fixture's default header/column order matches what
+    a real minimega instance sends, but a test may pass its own row with a
+    different order to prove that."""
+    return {
+        "Host": host,
+        "Header": ["id", "name", "state", "uptime", "uuid"],
+        "Tabular": [["0", name, "RUNNING", "1m0s", uuid]],
+        "Error": "",
+    }
+
+
+def _clients_row(uuid, hostname, host="gibson1336", header=None):
+    """One `cc clients` per-host row, with the tabular row derived from the
+    header so a caller can drop columns without misaligning the values."""
+    header = header or ["uuid", "hostname", "arch", "os"]
+    values = {"uuid": uuid, "hostname": hostname, "arch": "amd64", "os": "linux"}
+
+    return {
+        "Host": host,
+        "Header": header,
+        "Tabular": [[values[col] for col in header]],
+        "Error": "",
+    }
 
 
 # Multi-host cc_exitcode fan-out: the sibling host that doesn't run the VM
@@ -45,13 +134,29 @@ _WITH_CODE = [
 ]
 
 
-def test_mm_cc_all_hosts_returns_all_rows_and_restores_raise_errors():
+def test_mm_cc_all_hosts_suppresses_host_errors_and_restores_the_flag():
+    # With _raise_errors set (the binding default) a sibling host's "no client"
+    # row aborts the whole call and discards the valid row...
+    mm = _StubMM([_WITH_CODE])
+
+    with pytest.raises(minimega.Error):
+        mm.cc_exitcode("1", "foo")
+
+    # ...which is precisely what mm_cc_all_hosts exists to suppress.
     mm = _StubMM([_WITH_CODE])
 
     out = utils.mm_cc_all_hosts(mm, mm.cc_exitcode, "1", "foo")
 
     assert out == _WITH_CODE  # sibling error row NOT dropped
     assert mm._raise_errors is True  # restored after the call
+
+
+def test_mm_cc_all_hosts_forwards_kwargs():
+    mm = _StubMM(vm_info_rows=[_vm_info_row("foo", "abc-1234")])
+
+    utils.mm_cc_all_hosts(mm, mm.vm_info, summary="summary")
+
+    assert mm.vm_info_kwargs == {"summary": "summary"}
 
 
 def test_mm_cc_exitcode_wait_picks_host_with_code_ignoring_sibling(monkeypatch):
@@ -88,91 +193,555 @@ def test_mm_cc_exitcode_wait_grace_exceeded(monkeypatch):
         utils.mm_cc_exitcode_wait(mm, "1", "foo", grace=0.0, poll_rate=0.0)
 
 
+def test_mm_cc_exitcode_wait_surfaces_host_errors_in_the_timeout(monkeypatch):
+    monkeypatch.setattr(utils.time, "sleep", lambda *_: None)
+
+    # minimega's complaint must survive into the timeout message.
+    rows = [{"Host": "gibson1336", "Error": "no such command id 99", "Response": ""}]
+    mm = _StubMM([rows])
+
+    with pytest.raises(RuntimeError, match="no such command id 99"):
+        utils.mm_cc_exitcode_wait(mm, "99", "foo", grace=0.0, poll_rate=0.0)
+
+
 def test_mm_command_id_reads_data_field():
     # minimega returns the new command id (an int) in the Data field; it must be
     # stringified to match the string id in `cc commands` tabular output.
     resp = [{"Host": "headnode", "Data": 36, "Error": ""}]
 
-    assert utils.mm_command_id(resp) == "36"
+    with pytest.deprecated_call():
+        assert utils.mm_command_id(resp) == "36"
 
 
-def test_mm_command_id_picks_host_carrying_data():
-    # On multi-host, only the host that created the command carries Data; others
-    # may report Data=None. The id must still be found.
-    resp = [
-        {"Host": "gibson1337", "Data": None, "Error": ""},
-        {"Host": "gibson1336", "Data": 7, "Error": ""},
-    ]
+# Broadcast: every host creates its own command, so the ids deliberately disagree.
+_SPLIT_IDS = [
+    {"Host": "gibson1336", "Data": 21, "Error": ""},
+    {"Host": "gibson1337", "Data": 20, "Error": ""},
+]
 
-    assert utils.mm_command_id(resp) == "7"
+
+def test_mm_command_ids_maps_every_host_to_its_own_id():
+    assert utils.mm_command_ids(_SPLIT_IDS) == {"gibson1336": "21", "gibson1337": "20"}
+
+
+def test_mm_command_id_for_host_picks_the_owning_hosts_id():
+    # The client lives on gibson1337, so its id is 20 -- not the 21 that the
+    # local/headnode leg reports first and that mm_command_id would return.
+    assert utils.mm_command_id_for_host(_SPLIT_IDS, "gibson1337") == "20"
+    with pytest.deprecated_call():
+        assert utils.mm_command_id(_SPLIT_IDS) == "21"
+
+
+def test_mm_command_id_for_host_raises_when_that_host_never_created_it():
+    # The owning host having no id means the command was created somewhere else
+    # entirely (another namespace). Nothing to wait for -- fail immediately.
+    with pytest.raises(RuntimeError, match="never created its own copy"):
+        utils.mm_command_id_for_host(_SPLIT_IDS, "gibson1338")
 
 
 def test_mm_command_id_missing_data_raises():
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError), pytest.deprecated_call():
         utils.mm_command_id([{"Host": "headnode", "Data": None, "Error": ""}])
 
 
 # cc client returns one per-host response per cluster host; each carries a
 # Tabular of registered miniccc clients on that host.
 _CLIENTS_EMPTY = [{"Host": "gibson1337", "Header": [], "Tabular": [], "Error": ""}]
-_CLIENTS_OTHER = [
-    {
-        "Host": "gibson1337",
-        "Header": ["uuid", "hostname", "arch", "os"],
-        "Tabular": [["zzz-9999", "bar", "amd64", "linux"]],
-        "Error": "",
-    }
-]
-_CLIENTS_MATCH = [
-    {
-        "Host": "gibson1336",
-        "Header": ["uuid", "hostname", "arch", "os"],
-        "Tabular": [["abc-1234", "foo", "amd64", "linux"]],
-        "Error": "",
-    }
-]
+_CLIENTS_OTHER = [_clients_row("zzz-9999", "bar", host="gibson1337")]
+_CLIENTS_MATCH = [_clients_row("abc-1234", "foo")]
+_VM_INFO_FOO = [_vm_info_row("foo", "abc-1234")]
 
 
-def test_mm_cc_client_active_found_by_hostname():
-    mm = _StubMM(client_effects=[_CLIENTS_MATCH])
+def test_mm_cc_client_locate_found_by_hostname():
+    mm = _StubMM(client_effects=[_CLIENTS_MATCH], vm_info_rows=_VM_INFO_FOO)
 
-    utils.mm_cc_client_active(mm, "foo", grace=60.0, poll_rate=0.0)
+    assert utils.mm_cc_client_locate(mm, "foo", grace=60.0, poll_rate=0.0) == (
+        "abc-1234",
+        "gibson1336",
+    )
+    assert mm.client_calls == 1
+
+
+def test_mm_cc_client_locate_accepts_a_uuid_with_by_uuid():
+    # The name lookup finds nothing (there is no VM called "abc-1234"), which is
+    # what tells us the caller handed us a UUID rather than a name.
+    mm = _StubMM(client_effects=[_CLIENTS_MATCH], vm_info_rows=_VM_INFO_FOO)
+
+    utils.mm_cc_client_locate(mm, "abc-1234", grace=60.0, poll_rate=0.0, by_uuid=True)
 
     assert mm.client_calls == 1
 
 
-def test_mm_cc_client_active_found_by_uuid():
-    mm = _StubMM(client_effects=[_CLIENTS_MATCH])
+def test_mm_cc_client_locate_by_uuid_still_resolves_a_vm_name():
+    # by_uuid must still try the name lookup first.
+    mm = _StubMM(
+        client_effects=[[_clients_row("abc-1234", "site-a-rtr")]],
+        vm_info_rows=[_vm_info_row("Site_A.RTR", "abc-1234")],
+    )
 
-    utils.mm_cc_client_active(mm, "abc-1234", grace=60.0, poll_rate=0.0, by_uuid=True)
+    got = utils.mm_cc_client_locate(
+        mm, "Site_A.RTR", grace=0.0, poll_rate=0.0, by_uuid=True
+    )
 
-    assert mm.client_calls == 1
+    assert got == ("abc-1234", "gibson1336")
 
 
-def test_mm_cc_client_active_polls_until_visible(monkeypatch):
+def test_mm_cc_client_locate_matches_router_whose_guest_hostname_differs():
+    # A router's guest hostname is lowercased and '.'/'_' mapped to '-', so it
+    # differs from the minimega VM name.
+    mm = _StubMM(
+        client_effects=[[_clients_row("abc-1234", "site-a-rtr")]],
+        vm_info_rows=[_vm_info_row("Site_A.RTR", "abc-1234")],
+    )
+
+    assert utils.mm_cc_client_locate(mm, "Site_A.RTR", grace=0.0, poll_rate=0.0) == (
+        "abc-1234",
+        "gibson1336",
+    )
+
+
+def test_mm_cc_client_locate_never_matches_on_hostname():
+    # A matching hostname with a different uuid is a different VM.
+    mm = _StubMM(
+        client_effects=[[_clients_row("zzz-9999", "foo")]],
+        vm_info_rows=[_vm_info_row("Foo", "abc-1234")],
+    )
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        utils.mm_cc_client_locate(mm, "Foo", grace=0.0, poll_rate=0.0)
+
+
+def test_mm_cc_client_locate_unknown_vm_raises_only_after_grace(monkeypatch):
+    # One `vm info` miss is a sample, not proof -- retry until grace is up.
+    clock = _install_fake_clock(monkeypatch)
+    mm = _StubMM(client_effects=[_CLIENTS_MATCH], vm_info_rows=_VM_INFO_FOO)
+
+    with pytest.raises(RuntimeError, match="does not exist"):
+        utils.mm_cc_client_locate(mm, "nope", grace=30.0, poll_rate=1.0)
+
+    assert clock.now >= 30.0
+    assert mm.vm_info_calls > 1  # retried rather than resolved once up front
+
+
+def test_mm_cc_client_locate_polls_until_visible(monkeypatch):
     monkeypatch.setattr(utils.time, "sleep", lambda *_: None)
 
     # Two empty rounds (client not yet registered) before it appears.
-    mm = _StubMM(client_effects=[_CLIENTS_EMPTY, _CLIENTS_OTHER, _CLIENTS_MATCH])
+    mm = _StubMM(
+        client_effects=[_CLIENTS_EMPTY, _CLIENTS_OTHER, _CLIENTS_MATCH],
+        vm_info_rows=_VM_INFO_FOO,
+    )
 
-    utils.mm_cc_client_active(mm, "foo", grace=60.0, poll_rate=0.0)
+    utils.mm_cc_client_locate(mm, "foo", grace=60.0, poll_rate=0.0)
 
     assert mm.client_calls == 3
 
 
-def test_mm_cc_client_active_grace_exceeded(monkeypatch):
+def test_mm_cc_client_locate_grace_exceeded(monkeypatch):
     monkeypatch.setattr(utils.time, "sleep", lambda *_: None)
 
     # Client never appears within the grace window.
-    mm = _StubMM(client_effects=[_CLIENTS_EMPTY] * 3)
+    mm = _StubMM(client_effects=[_CLIENTS_EMPTY] * 3, vm_info_rows=_VM_INFO_FOO)
 
-    with pytest.raises(RuntimeError):
-        utils.mm_cc_client_active(mm, "foo", grace=0.0, poll_rate=0.0)
+    with pytest.raises(RuntimeError, match="timed out"):
+        utils.mm_cc_client_locate(mm, "foo", grace=0.0, poll_rate=0.0)
 
 
-def test_mm_cc_client_active_ignores_non_matching_clients():
+def test_mm_cc_client_locate_ignores_non_matching_clients():
     # Other clients are registered, but ours isn't -- must NOT return.
+    mm = _StubMM(client_effects=[_CLIENTS_OTHER], vm_info_rows=_VM_INFO_FOO)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        utils.mm_cc_client_locate(mm, "foo", grace=0.0, poll_rate=0.0)
+
+
+def test_mm_cc_client_seen_matches_by_uuid():
+    # uuid comparison is case-insensitive.
+    mm = _StubMM(client_effects=[_CLIENTS_MATCH])
+
+    assert utils.mm_cc_client_seen(mm, "ABC-1234") == "gibson1336"
+
+
+def test_mm_cc_client_seen_returns_none_when_nothing_matches():
     mm = _StubMM(client_effects=[_CLIENTS_OTHER])
 
-    with pytest.raises(RuntimeError):
-        utils.mm_cc_client_active(mm, "foo", grace=0.0, poll_rate=0.0)
+    assert utils.mm_cc_client_seen(mm, "abc-1234") is None
+
+
+def test_mm_cc_client_seen_returns_the_host_owning_the_uuid():
+    # Guest hostnames are not unique; the decoy is listed first.
+    mm = _StubMM(
+        client_effects=[
+            [
+                _clients_row("zzz-9999", "foo", host="gibson1336"),
+                _clients_row("abc-1234", "foo", host="gibson1337"),
+            ]
+        ]
+    )
+
+    assert utils.mm_cc_client_seen(mm, "abc-1234") == "gibson1337"
+
+
+def test_mm_cc_client_locate_returns_the_uuid_owner_not_a_hostname_decoy():
+    # cc ids are per-host, so the wrong host would wait forever.
+    mm = _StubMM(
+        client_effects=[
+            [
+                _clients_row("zzz-9999", "foo", host="gibson1336"),
+                _clients_row("abc-1234", "foo", host="gibson1337"),
+            ]
+        ],
+        vm_info_rows=_VM_INFO_FOO,
+    )
+
+    assert utils.mm_cc_client_locate(mm, "foo") == ("abc-1234", "gibson1337")
+
+
+def test_mm_cc_client_seen_tolerates_a_host_row_with_no_header_or_tabular():
+    # A host with no cc traffic reports None rather than [].
+    mm = _StubMM(
+        client_effects=[
+            [{"Host": "gibson1337", "Header": None, "Tabular": None, "Error": ""}]
+        ]
+    )
+
+    assert utils.mm_cc_client_seen(mm, "abc-1234") is None
+
+
+def test_mm_vm_uuid_tolerates_a_host_with_no_vms():
+    # `vm info summary` leaves Tabular null for a host with zero VMs.
+    mm = _StubMM(
+        vm_info_rows=[
+            {"Host": "gibson1337", "Header": [], "Tabular": None, "Error": ""},
+            _vm_info_row("foo", "abc-1234"),
+        ]
+    )
+
+    assert utils.mm_vm_uuid(mm, "foo") == "abc-1234"
+    assert utils.mm_vm_uuid(mm, "absent") is None
+
+
+def test_mm_vm_uuid_reads_columns_from_a_differently_ordered_header():
+    # Nothing pins column order -- the code must look up "name"/"uuid" in
+    # Header rather than assuming fixed offsets.
+    row = {
+        "Host": "gibson1336",
+        "Header": ["uuid", "id", "name", "state"],
+        "Tabular": [["abc-1234", "0", "foo", "RUNNING"]],
+        "Error": "",
+    }
+    mm = _StubMM(vm_info_rows=[row])
+
+    assert utils.mm_vm_uuid(mm, "foo") == "abc-1234"
+
+
+def test_mm_vm_uuid_returns_none_when_header_lacks_name_or_uuid():
+    row = {
+        "Host": "gibson1336",
+        "Header": ["id", "state"],
+        "Tabular": [["0", "RUNNING"]],
+        "Error": "",
+    }
+    mm = _StubMM(vm_info_rows=[row])
+
+    assert utils.mm_vm_uuid(mm, "foo") is None
+
+
+# `cc commands` per-host rows: [id, prefix, command, responses, ...].
+def _cc_cmd_row(host="gibson1336", **cols):
+    """One `cc commands` per-host response. Pass any subset of columns by name."""
+    values = {"id": "7", "prefix": "", "command": "[whoami]", "responses": "0"}
+    values.update(cols)
+
+    return {
+        "Host": host,
+        "Header": list(utils.CC_CMD_COLUMNS),
+        "Tabular": [[values.get(col, "") for col in utils.CC_CMD_COLUMNS]],
+        "Error": "",
+    }
+
+
+_CMD_ANSWERED = [
+    {"Host": "gibson1337", "Tabular": None, "Error": ""},
+    _cc_cmd_row(responses="1"),
+]
+_CMD_UNANSWERED = [_cc_cmd_row(responses="0")]
+
+
+def test_mm_wait_for_cmd_returns_once_a_host_reports_a_response():
+    # Also covers a sibling host whose Tabular is null.
+    mm = _StubMM(cc_commands_rows=_CMD_ANSWERED)
+
+    utils.mm_wait_for_cmd(mm, "7", poll_rate=0.0)
+
+
+def test_mm_wait_for_cmd_default_is_unbounded(monkeypatch):
+    # With no timeout and no client, the wait must never give up on its own.
+    clock = _install_fake_clock(monkeypatch)
+
+    mm = _StubMM(cc_commands_effects=[_CMD_UNANSWERED] * 400 + [_CMD_ANSWERED])
+
+    utils.mm_wait_for_cmd(mm, "7")  # no client, no timeout override
+
+    # Pinned exactly: scorch's responsiveness is bounded by the poll interval.
+    assert clock.now == 400.0
+    assert mm.cc_commands_calls == 401
+    assert settings.CC_CMD_GRACE == 0.0
+
+
+def test_mm_wait_for_cmd_unbounded_with_live_client_waits_past_client_grace(
+    monkeypatch,
+):
+    # A registered client must never cause the unbounded wait to be abandoned.
+    clock = _install_fake_clock(monkeypatch)
+
+    mm = _StubMM(
+        cc_commands_effects=[_CMD_UNANSWERED] * 400 + [_CMD_ANSWERED],
+        client_effects=[_CLIENTS_MATCH],  # visible on every poll
+    )
+
+    utils.mm_wait_for_cmd(mm, "7", client="abc-1234")
+
+    assert clock.now > 300.0
+    assert mm.cc_commands_calls == 401
+    assert mm.client_calls > 0  # liveness was actually polled, not skipped
+
+
+def test_mm_wait_for_cmd_unbounded_raises_once_client_absence_exceeds_grace(
+    monkeypatch,
+):
+    _install_fake_clock(monkeypatch)
+
+    # An absence outlasting client_grace ends even an unbounded wait.
+    mm = _StubMM(
+        cc_commands_rows=_CMD_UNANSWERED,
+        client_effects=[_CLIENTS_EMPTY],
+    )
+
+    with pytest.raises(RuntimeError, match=r"client abc-1234.*cc command 7"):
+        utils.mm_wait_for_cmd(mm, "7", client="abc-1234", client_grace=50.0)
+
+
+def test_mm_wait_for_cmd_tolerates_a_single_missed_liveness_poll(monkeypatch):
+    _install_fake_clock(monkeypatch)
+
+    # One missed liveness check is a mesh hiccup, not a dead client.
+    mm = _StubMM(
+        cc_commands_effects=[_CMD_UNANSWERED] * 25 + [_CMD_ANSWERED],
+        client_effects=[_CLIENTS_EMPTY, _CLIENTS_MATCH],
+    )
+
+    utils.mm_wait_for_cmd(mm, "7", client="abc-1234", client_grace=15.0)
+
+    assert mm.client_calls >= 2  # both the miss and the recovery were polled
+
+
+def test_mm_wait_for_cmd_positive_timeout_still_enforces_wall_clock_deadline(
+    monkeypatch,
+):
+    # Passing a positive timeout must still bound the wait in wall-clock time,
+    # independent of any client supervision.
+    clock = _install_fake_clock(monkeypatch)
+
+    mm = _StubMM(cc_commands_rows=_CMD_UNANSWERED)  # never answers
+
+    with pytest.raises(RuntimeError, match=r"timed out after .*timeout=100"):
+        utils.mm_wait_for_cmd(mm, "7", timeout=100.0)
+
+    assert clock.now >= 100.0
+
+
+# `cc commands` row with a prefix that never accumulates enough responses.
+_PREFIX_UNANSWERED = [_cc_cmd_row(id="9", prefix="testing", responses="0")]
+
+
+def test_mm_wait_for_prefix_is_bounded_by_default(monkeypatch):
+    # Unlike mm_wait_for_cmd, a prefix targets a whole filter with no single
+    # client to supervise, so it must stay bounded by CC_SEND_GRACE by default.
+    clock = _install_fake_clock(monkeypatch)
+
+    mm = _StubMM(cc_commands_rows=_PREFIX_UNANSWERED)
+
+    with pytest.raises(RuntimeError, match=r"timed out after .*timeout=300"):
+        utils.mm_wait_for_prefix(mm, "testing", 1)
+
+    assert clock.now >= settings.CC_SEND_GRACE
+    assert settings.CC_SEND_GRACE == 300.0
+
+
+def test_wait_log_due_gates_by_interval_then_doubles_up_to_max(monkeypatch):
+    clock = _install_fake_clock(monkeypatch)
+
+    log = utils._WaitLog(interval=5.0, max_interval=100.0)
+
+    assert log.due() is False  # nothing has elapsed yet
+
+    clock.sleep(5.0)
+    assert log.due() is True  # fires exactly at the first interval
+    assert log.due() is False  # must not immediately re-fire
+    assert log.interval == 10.0  # doubled
+
+    clock.sleep(10.0)
+    assert log.due() is True
+    assert log.interval == 20.0
+
+    clock.sleep(20.0)
+    assert log.due() is True
+    assert log.interval == 40.0
+
+    clock.sleep(40.0)
+    assert log.due() is True
+    assert log.interval == 80.0
+
+    clock.sleep(80.0)
+    assert log.due() is True
+    assert log.interval == 100.0  # saturates: min(160, 100)
+
+    clock.sleep(100.0)
+    assert log.due() is True
+    assert log.interval == 100.0  # stays saturated
+
+
+# --- host-scoped cc command identity ------------------------------------
+#
+# Observed live: the owning host (gibson1337) has our answered command at id 20,
+# while the host answering first has an unrelated one at id 21.
+_SPLIT_COMMANDS = [
+    _cc_cmd_row("gibson1336", id="21", responses="0", sent="[exp/other.sh]"),
+    _cc_cmd_row("gibson1337", id="20", responses="1", sent="[exp/ours.sh]"),
+]
+
+
+def test_mm_wait_for_cmd_scoped_to_owning_host_finds_its_id():
+    mm = _StubMM(cc_commands_rows=_SPLIT_COMMANDS)
+
+    utils.mm_wait_for_cmd(mm, "20", host="gibson1337", poll_rate=0.0)
+
+
+def test_mm_wait_for_cmd_ignores_the_same_id_on_another_host(monkeypatch):
+    # id 21 exists only on the host that does NOT own the client.
+    clock = _install_fake_clock(monkeypatch)
+    mm = _StubMM(cc_commands_rows=_SPLIT_COMMANDS)
+
+    with pytest.raises(RuntimeError, match="never appeared on host gibson1337"):
+        utils.mm_wait_for_cmd(mm, "21", host="gibson1337", appear_grace=30.0)
+
+    assert clock.now >= 30.0
+
+
+def test_mm_wait_for_cmd_content_mismatch_counts_as_absent(monkeypatch):
+    # Right host, right id, wrong payload: on this host that id belongs to some
+    # other command, so ours was never created here.
+    clock = _install_fake_clock(monkeypatch)
+    mm = _StubMM(cc_commands_rows=_SPLIT_COMMANDS)
+
+    with pytest.raises(RuntimeError, match="never appeared"):
+        utils.mm_wait_for_cmd(
+            mm,
+            "20",
+            host="gibson1337",
+            match_column="sent",
+            match_value="[exp/not-ours.sh]",
+            appear_grace=30.0,
+        )
+
+    assert clock.now >= 30.0
+
+
+def test_mm_wait_for_cmd_appearance_is_bounded_but_the_response_is_not(monkeypatch):
+    # Once the row appears, appear_grace must not also cap the response wait.
+    clock = _install_fake_clock(monkeypatch)
+    mm = _StubMM(
+        cc_commands_effects=[[_cc_cmd_row("gibson1336", responses="0")]] * 400
+        + [[_cc_cmd_row("gibson1336", responses="1")]],
+    )
+
+    utils.mm_wait_for_cmd(mm, "7", host="gibson1336", appear_grace=30.0, poll_rate=1.0)
+
+    assert clock.now == 400.0  # far past appear_grace, without raising
+
+
+def test_mm_wait_for_cmd_without_a_host_keeps_the_legacy_any_host_behaviour():
+    # With no host to scope to, the appearance phase is skipped entirely.
+    mm = _StubMM(cc_commands_rows=_CMD_ANSWERED)
+
+    utils.mm_wait_for_cmd(mm, "7", poll_rate=0.0)
+
+
+def test_mm_cc_client_seen_returns_the_owning_host():
+    mm = _StubMM(client_effects=[[_clients_row("abc-1234", "foo", host="gibson1337")]])
+
+    assert utils.mm_cc_client_seen(mm, "abc-1234") == "gibson1337"
+
+
+def test_mm_cc_client_seen_returns_none_when_absent():
+    mm = _StubMM(client_effects=[_CLIENTS_OTHER])
+
+    assert utils.mm_cc_client_seen(mm, "abc-1234") is None
+
+
+def test_mm_cc_client_locate_returns_uuid_and_host():
+    mm = _StubMM(
+        client_effects=[[_clients_row("abc-1234", "foo", host="gibson1337")]],
+        vm_info_rows=[_vm_info_row("foo", "abc-1234")],
+    )
+
+    assert utils.mm_cc_client_locate(mm, "foo", grace=0.0, poll_rate=0.0) == (
+        "abc-1234",
+        "gibson1337",
+    )
+
+
+def test_mm_cc_exitcode_wait_ignores_a_sibling_hosts_answer(monkeypatch):
+    # A sibling holding an unrelated command at the same id must never be
+    # mistaken for the answer.
+    clock = _install_fake_clock(monkeypatch)
+    rows = [{"Host": "gibson1336", "Error": "", "Response": "0"}]
+    mm = _StubMM([rows])
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        utils.mm_cc_exitcode_wait(mm, "20", "foo", grace=5.0, host="gibson1337")
+
+    assert clock.now >= 5.0
+
+
+def test_mm_wait_for_prefix_sums_responses_across_hosts():
+    # num_responses is a namespace-wide expectation while each host counts only
+    # the clients it owns, so a per-host comparison can never reach it on a mesh.
+    mm = _StubMM(
+        cc_commands_rows=[
+            _cc_cmd_row("gibson1336", id="9", prefix="testing", responses="2"),
+            _cc_cmd_row("gibson1337", id="8", prefix="testing", responses="3"),
+        ]
+    )
+
+    utils.mm_wait_for_prefix(mm, "testing", 5, poll_rate=0.0)
+
+
+def test_mm_wait_for_prefix_ignores_other_prefixes(monkeypatch):
+    clock = _install_fake_clock(monkeypatch)
+    mm = _StubMM(
+        cc_commands_rows=[_cc_cmd_row("gibson1336", prefix="other", responses="9")]
+    )
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        utils.mm_wait_for_prefix(mm, "testing", 1, timeout=5.0)
+
+    assert clock.now >= 5.0
+
+
+def test_cc_cmd_columns_match_minimega_cc_cli():
+    # Source of truth: cmd/minimega/cc_cli.go, cliCCCommand's resp.Header.
+    assert utils.CC_CMD_COLUMNS == (
+        "id",
+        "prefix",
+        "command",
+        "responses",
+        "background",
+        "once",
+        "sent",
+        "received",
+        "connectivity",
+        "level",
+        "filter",
+    )

--- a/src/python/phenix_apps/common/utils.py
+++ b/src/python/phenix_apps/common/utils.py
@@ -235,7 +235,59 @@ def expand_shorthand(short: str) -> list:
     return [short]
 
 
-def mm_send(mm: minimega.minimega, vm: str, src: str, dst: str) -> None:
+# `cc commands` columns, in order (minimega cmd/minimega/cc_cli.go)
+CC_CMD_COLUMNS = (
+    "id",
+    "prefix",
+    "command",
+    "responses",
+    "background",
+    "once",
+    "sent",
+    "received",
+    "connectivity",
+    "level",
+    "filter",
+)
+
+
+def _cc_cmd_field(row: list, column: str) -> str | None:
+    """Value of ``column`` in a ``cc commands`` row, or None if truncated."""
+    idx = CC_CMD_COLUMNS.index(column)
+
+    return row[idx] if idx < len(row) else None
+
+
+class _WaitLog:
+    """Rate-limit a poll loop's "still waiting" line, backing off as the wait grows."""
+
+    def __init__(
+        self,
+        interval: float = phenix_settings.CC_LOG_INTERVAL,
+        max_interval: float = phenix_settings.CC_LOG_MAX_INTERVAL,
+    ) -> None:
+        self.interval = interval
+        self.max_interval = max_interval
+        self._due = time.monotonic() + interval
+
+    def due(self) -> bool:
+        """True at most once per interval; advances to the next one."""
+        if time.monotonic() < self._due:
+            return False
+
+        self.interval = min(self.interval * 2, self.max_interval)
+        self._due = time.monotonic() + self.interval
+
+        return True
+
+
+def mm_send(
+    mm: minimega.minimega,
+    vm: str,
+    src: str,
+    dst: str,
+    grace: float = phenix_settings.CC_CLIENT_GRACE,
+) -> None:
     if not os.path.exists(src):
         raise ValueError(f"{src} not found locally")
 
@@ -251,7 +303,7 @@ def mm_send(mm: minimega.minimega, vm: str, src: str, dst: str) -> None:
     if Path("/tmp/miniccc-mounts").is_dir():
         base = "/tmp/miniccc-mounts"
 
-    mm_cc_client_active(mm, vm)
+    mm_cc_client_active(mm, vm, grace=grace)
 
     with tempfile.TemporaryDirectory(dir=base) as tmp:
         vm_dst = os.path.join(tmp, dst.strip("/"))
@@ -275,7 +327,13 @@ def mm_send(mm: minimega.minimega, vm: str, src: str, dst: str) -> None:
             time.sleep(1.0)
 
 
-def mm_recv(mm: minimega.minimega, vm: str, src: list[str] | str, dst: str) -> None:
+def mm_recv(
+    mm: minimega.minimega,
+    vm: str,
+    src: list[str] | str,
+    dst: str,
+    grace: float = phenix_settings.CC_CLIENT_GRACE,
+) -> None:
     """
     Transfer one or more files from a VM to a destination on the host using miniccc mounts.
     """
@@ -292,7 +350,7 @@ def mm_recv(mm: minimega.minimega, vm: str, src: list[str] | str, dst: str) -> N
     if Path("/tmp/miniccc-mounts").is_dir():
         base = "/tmp/miniccc-mounts"
 
-    mm_cc_client_active(mm, vm)
+    mm_cc_client_active(mm, vm, grace=grace)
 
     with tempfile.TemporaryDirectory(dir=base) as tmp:
         if isinstance(src, str):
@@ -346,128 +404,234 @@ def mm_get_cc_path(mm: minimega.minimega) -> Path | None:
     return cc_path
 
 
-# seconds between cc client checks; matches Go util/mm c2ActiveCheckInterval
-CC_POLL_RATE = float(os.environ.get("PHENIX_CC_POLL_RATE", 2.0))
-# bounded window to ride out the gap between a response being counted and the
-# exit code being recorded
-CC_EXITCODE_GRACE = float(os.environ.get("PHENIX_CC_EXITCODE_GRACE", 10.0))
-# bounded window for the miniccc client to register on a minimega host;
-# matches Go util/mm DefaultC2Timeout
-CC_CLIENT_GRACE = float(os.environ.get("PHENIX_CC_CLIENT_GRACE", 300.0))
-
-
-def mm_cc_all_hosts(mm: minimega.minimega, method, *args) -> list:
-    """Call an mm cc_* method and return ALL per-host response rows, without
-    raising on an individual host's error.
-
-    On a multi-host deployments, cc_exitcode / cc_responses fan out across the
-    namespace: the host running the VM returns the data while sibling hosts
-    report "no client <vm>" / "no responses for <id>". With raise_errors=True
-    (the binding default) _get_response raises on the FIRST host error and
-    discards the valid row, so we temporarily disable it and let the caller scan
-    every row.
+def mm_cc_all_hosts(mm: minimega.minimega, method, *args, **kwargs) -> list:
+    """Call an mm method and return every per-host response row, without raising
+    on one host's error.
     """
     saved = mm._raise_errors
     mm._raise_errors = False
 
     try:
-        return method(*args)
+        return method(*args, **kwargs)
     finally:
         mm._raise_errors = saved
+
+
+def mm_cc_client_seen(mm: minimega.minimega, uuid: str) -> str | None:
+    """Minimega host reporting ``uuid`` in ``cc clients``, or None.
+
+    A single miss is a sample, not proof -- miniccc heartbeats every ~5s.
+    """
+    for resp in mm_cc_all_hosts(mm, mm.cc_clients):
+        header = resp.get("Header") or []
+
+        if "uuid" not in header:
+            continue
+
+        idx = header.index("uuid")
+
+        for row in resp.get("Tabular") or []:
+            if idx < len(row) and row[idx].lower() == uuid.lower():
+                return resp.get("Host")
+
+    return None
+
+
+def mm_cc_client_locate(
+    mm: minimega.minimega,
+    vm: str,
+    grace: float = phenix_settings.CC_CLIENT_GRACE,
+    poll_rate: float = phenix_settings.CC_POLL_RATE,
+    by_uuid: bool = False,
+) -> tuple[str, str]:
+    """Block until the miniccc client for ``vm`` registers; return its
+    ``(uuid, host)``.
+
+    ``host`` is the minimega host that owns the client -- cc command ids are
+    per-host, so id lookups must be aimed at it. ``by_uuid=True`` allows ``vm``
+    to already be a UUID.
+    """
+    start = time.monotonic()
+    deadline = start + grace
+    wait_log = _WaitLog()
+    uuid = None
+
+    while True:
+        # Retried, not resolved once: one miss is a sample, not proof.
+        if uuid is None:
+            uuid = mm_vm_uuid(mm, vm)
+
+        candidate = uuid or (vm if by_uuid else None)
+
+        if candidate is not None:
+            host = mm_cc_client_seen(mm, candidate)
+
+            if host is not None:
+                return candidate, host
+
+        if time.monotonic() >= deadline:
+            if candidate is None:
+                raise RuntimeError(f"vm {vm} does not exist in the namespace")
+
+            raise RuntimeError(
+                f"timed out after {grace}s waiting for miniccc client on VM "
+                f"{vm} (uuid {candidate})"
+            )
+
+        if wait_log.due():
+            logger.warning(
+                f"miniccc client for VM {vm} (uuid {candidate}) not yet registered "
+                f"after {time.monotonic() - start:.1f}s (grace {grace}s); retrying"
+            )
+
+        time.sleep(poll_rate)
+
+
+def mm_cc_filter_vm(
+    mm: minimega.minimega, vm: str, grace: float = phenix_settings.CC_CLIENT_GRACE
+) -> tuple[str, str]:
+    """Point the cc filter at ``vm`` by UUID; return its ``(uuid, host)``.
+
+    By UUID, not name: ``name`` is not a cc filter field, so ``cc filter
+    name=`` matches on tags and silently targets zero clients.
+    """
+    uuid, host = mm_cc_client_locate(mm, vm, grace=grace)
+    mm.cc_filter(f"uuid={uuid}")
+
+    return uuid, host
+
+
+def mm_cc_send_wait(
+    mm: minimega.minimega,
+    vm: str,
+    src: str,
+    exp_name: str,
+    grace: float = phenix_settings.CC_SEND_GRACE,
+) -> None:
+    """Send file ``src`` to ``vm`` via cc and wait for it to land.
+
+    The filename identifies the invocation, so the ``sent`` column is matched
+    too.
+    """
+    uuid, host = mm_cc_filter_vm(mm, vm)
+    cmd_id = mm_command_id_for_host(mm.cc_send(src), host)
+
+    mm_wait_for_cmd(
+        mm,
+        cmd_id,
+        timeout=grace,
+        client=uuid,
+        host=host,
+        match_column="sent",
+        match_value=f"[{exp_name}/{os.path.basename(src)}]",
+    )
 
 
 def mm_cc_client_active(
     mm: minimega.minimega,
     vm: str,
-    grace: float = CC_CLIENT_GRACE,
-    poll_rate: float = CC_POLL_RATE,
+    grace: float = phenix_settings.CC_CLIENT_GRACE,
+    poll_rate: float = phenix_settings.CC_POLL_RATE,
     by_uuid: bool = False,
-) -> None:
-    """Block until the miniccc client for ``vm`` is registered with minimega.
+) -> str:
+    """DEPRECATED -- use :func:`mm_cc_client_locate`, which also returns the
+    minimega host owning the client."""
+    warnings.warn(
+        "mm_cc_client_active does not return the host owning the client. "
+        "Use mm_cc_client_locate instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    Mirrors the Go util/mm IsC2ClientActive pre-flight. The miniccc agent
-    can be transiently unresolvable which causes downstream cc_mount /
-    cc_exec / cc_send calls to fail with "no such client: <uuid>". Polls
-    ``cc client`` until a row matching ``vm`` appears on any host, or raises
-    RuntimeError once ``grace`` is exceeded.
+    uuid, _ = mm_cc_client_locate(
+        mm, vm, grace=grace, poll_rate=poll_rate, by_uuid=by_uuid
+    )
 
-    By default ``vm`` is matched against the agent's self-reported hostname --
-    this is intentionally strict so a VM that hasn't yet booted to the
-    expected hostname (e.g. a Windows VM mid-rename) is not considered ready.
-    Pass ``by_uuid=True`` to match by VM UUID instead.
-    """
-    column = "uuid" if by_uuid else "hostname"
-    deadline = time.monotonic() + grace
-
-    while True:
-        responses = mm_cc_all_hosts(mm, mm.cc_clients)
-
-        for resp in responses:
-            header = resp.get("Header") or []
-            tabular = resp.get("Tabular") or []
-
-            if column not in header:
-                continue
-
-            col_idx = header.index(column)
-            for row in tabular:
-                if col_idx < len(row) and row[col_idx] == vm:
-                    return
-
-        if time.monotonic() >= deadline:
-            raise RuntimeError(
-                f"timed out after {grace}s waiting for miniccc client on VM {vm}"
-            )
-
-        time.sleep(poll_rate)
+    return uuid
 
 
 def mm_cc_exitcode_wait(
     mm: minimega.minimega,
     cmd_id: str,
     client: str,
-    grace: float = CC_EXITCODE_GRACE,
-    poll_rate: float = CC_POLL_RATE,
+    grace: float = phenix_settings.CC_EXITCODE_GRACE,
+    poll_rate: float = phenix_settings.CC_POLL_RATE,
+    host: str | None = None,
 ) -> dict:
-    """Wait for and return the cc exit-code response row for an already-completed
-    command, tolerating multi-host fan-out.
+    """Wait for and return the cc exit-code row for a completed command.
 
-    Only the host running the VM has the code; sibling hosts report
-    "no client <vm>". Scan every host row and return the one carrying the code.
-    ``grace`` bounds the wait for the gap between a response being counted and
-    the exit code being recorded, raising RuntimeError if exceeded.
+    Only the host running the VM has the code; siblings report "no client". Pass
+    ``host`` to scope the lookup -- cc ids are per-host. minimega's own errors
+    are folded into the timeout message.
     """
+    if host is None:
+        logger.warning(
+            f"mm_cc_exitcode_wait called without a host for cmd {cmd_id}; cc ids "
+            "are per-host, so this may read a sibling host's unrelated command"
+        )
+
     deadline = time.monotonic() + grace
+    wait_log = _WaitLog()
+    errors = []
 
     while True:
         rows = mm_cc_all_hosts(mm, mm.cc_exitcode, cmd_id, client)
 
+        errors = [row["Error"] for row in rows if row.get("Error")]
+
         for row in rows:
+            if host is not None and row.get("Host") != host:
+                continue
+
             if not row.get("Error") and row.get("Response") not in (None, ""):
                 return row
+
+        detail = f"; last errors from minimega: {'; '.join(errors)}" if errors else ""
 
         if time.monotonic() >= deadline:
             raise RuntimeError(
                 f"timed out after {grace}s waiting for exit code of command "
-                f"{cmd_id} on {client}"
+                f"{cmd_id} on {client}{detail}"
             )
 
-        logger.warning(
-            f"exit code for {client} (cmd {cmd_id}) not yet reported by any host; "
-            f"retrying"
-        )
+        if wait_log.due():
+            logger.warning(
+                f"exit code for {client} (cmd {cmd_id}) not yet reported by any "
+                f"host; retrying{detail}"
+            )
+
         time.sleep(poll_rate)
 
 
-def mm_command_id(resp: list) -> str:
-    """Return the id of the command just created by cc_exec / cc_exec_once /
-    cc_send. minimega returns the new id in the response's ``Data`` field (see
-    Namespace.NewCommand), so read it from the call that created the command
-    rather than re-querying ``cc commands`` and guessing the last row -- the
-    latter is racy when another component issues into the same namespace queue.
+def mm_command_ids(resp: list) -> dict[str, str]:
+    """Map each minimega host to the id it gave the command just created.
 
-    The id is stringified to match the string id in ``cc commands`` tabular
-    output (compared in mm_wait_for_cmd)."""
+    ``cc`` is broadcast and every host numbers the command from its own counter,
+    so there is no namespace-global id. Read from the creating call's ``Data``
+    field.
+    """
+    ids = {
+        row["Host"]: str(row["Data"])
+        for row in resp
+        if row.get("Data") is not None and row.get("Host")
+    }
+
+    if not ids:
+        raise RuntimeError(f"no command id in cc response: {resp!r}")
+
+    return ids
+
+
+def mm_command_id(resp: list) -> str:
+    """DEPRECATED -- use :func:`mm_command_id_for_host`; cc command ids are
+    per-host."""
+    warnings.warn(
+        "mm_command_id assumes a namespace-global cc command id, but ids are "
+        "per-host. Use mm_command_id_for_host instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     for row in resp:
         if row.get("Data") is not None:
             return str(row["Data"])
@@ -475,35 +639,61 @@ def mm_command_id(resp: list) -> str:
     raise RuntimeError(f"no command id in cc response: {resp!r}")
 
 
+def mm_command_id_for_host(resp: list, host: str) -> str:
+    """The id ``host`` assigned to the command just created. Missing means the
+    command went elsewhere."""
+    ids = mm_command_ids(resp)
+    cmd_id = ids.get(host)
+
+    if cmd_id is None:
+        raise RuntimeError(
+            f"host {host} owns the target client but never created its own copy "
+            f"of the command; only {sorted(ids)} did"
+        )
+
+    return cmd_id
+
+
 def mm_exec_wait(
     mm: minimega.minimega,
     vm: str,
     cmd: str,
     once: bool = True,
-    timeout: float = 0.0,
+    timeout: float = phenix_settings.CC_CMD_GRACE,
     poll_rate: float = 1.0,
     debug: bool = False,
+    client_grace: float = phenix_settings.CC_CLIENT_GRACE,
 ) -> dict:
-    mm_cc_client_active(mm, vm)
-    mm.cc_filter(f"name={vm}")
+    """Run ``cmd`` on ``vm`` via cc and wait for it to finish.
 
-    # Capture the new command's id directly from the cc_exec response rather than
-    # re-querying cc commands afterward.
+    ``timeout`` bounds the response wait; 0 (the default) waits indefinitely,
+    supervised instead by the client staying registered.
+    """
+    uuid, host = mm_cc_filter_vm(mm, vm, grace=client_grace)
+
     resp = mm.cc_exec_once(cmd) if once else mm.cc_exec(cmd)
-    cmd_id = mm_command_id(resp)
+    cmd_id = mm_command_id_for_host(resp, host)
 
     mm_wait_for_cmd(
-        mm=mm, cmd_id=cmd_id, timeout=timeout, poll_rate=poll_rate, debug=debug
+        mm=mm,
+        cmd_id=cmd_id,
+        timeout=timeout,
+        poll_rate=poll_rate,
+        debug=debug,
+        client=uuid,
+        client_grace=client_grace,
+        host=host,
+        # No content match: minimega re-renders the command as argv, so it will
+        # not compare equal.
     )
 
-    # The command has completed (mm_wait_for_cmd saw a response). Fetch the exit
-    # code by UUID; mm_cc_exitcode_wait scans all hosts and ignores the sibling
-    # "no client" rows that the multi-host fan-out returns. Fall back to the VM
-    # name if the UUID lookup comes back empty.
-    uuid = mm_vm_uuid(mm, vm)
-    grace = timeout if timeout else CC_EXITCODE_GRACE
     exit_resp = mm_cc_exitcode_wait(
-        mm, cmd_id, uuid or vm, grace=grace, poll_rate=poll_rate
+        mm,
+        cmd_id,
+        uuid or vm,
+        grace=phenix_settings.CC_EXITCODE_GRACE,
+        poll_rate=poll_rate,
+        host=host,
     )
 
     result = {
@@ -552,88 +742,150 @@ def mm_exec_wait(
 def mm_wait_for_cmd(
     mm: minimega.minimega,
     cmd_id: str,
-    timeout: float = 0.0,
+    timeout: float = phenix_settings.CC_CMD_GRACE,
     poll_rate: float = 1.0,
     debug: bool = False,
+    client: str | None = None,
+    client_grace: float = phenix_settings.CC_CLIENT_GRACE,
+    host: str | None = None,
+    match_column: str | None = None,
+    match_value: str | None = None,
+    appear_grace: float = phenix_settings.CC_SEND_GRACE,
 ) -> None:
-    def last_test(c):
-        return c[0] == cmd_id
+    """Block until cc command ``cmd_id`` has at least one response.
 
-    def done_test(c):
-        return int(c[3]) > 0
+    The row must appear on ``host`` within ``appear_grace``, then ``timeout``
+    (0 = unbounded) bounds the response wait, supervised by ``client`` staying
+    in ``cc clients``. ``match_column``/``match_value`` additionally require the
+    row's content to be ours.
+    """
+    start = time.monotonic()
+    deadline = start + timeout
+    appear_deadline = start + appear_grace
+    wait_log = _WaitLog()
+    last_seen = start
+    next_check = start + phenix_settings.CC_LIVENESS_INTERVAL
+    seen = host is None
 
-    waiting = True
-    counter = 0
-
-    while waiting:
+    while True:
         # >>> mm.cc_commands()
-        # [{'Host': 'harmonie', 'Response': '', 'Header': ['id', 'prefix', 'command', 'responses', 'background', 'once', 'sent', 'received', 'connectivity', 'level', 'filter'], 'Tabular': [['1', 'testing', '[/usr/bin/iperf3 --version]', '15', 'false', 'true', '[]', '[]', '', '', 'os=linux && iperf=1']], 'Error': '', 'Data': None}]
-        commands = mm.cc_commands()
+        # 'Header': ['id', 'prefix', 'command', 'responses', 'background', 'once', 'sent', 'received', 'connectivity', 'level', 'filter']
+        # 'Tabular': [['1', 'testing', '[/usr/bin/iperf3 --version]', '15', 'false', 'true', '[]', '[]', '', '', 'os=linux && iperf=1']]
+        for resp in mm_cc_all_hosts(mm, mm.cc_commands):
+            if host is not None and resp.get("Host") != host:
+                continue
 
-        for host in commands:
-            last = list(filter(last_test, host["Tabular"]))
-            done = list(filter(done_test, last))
+            for row in resp.get("Tabular") or []:
+                if not row or row[0] != cmd_id:
+                    continue
 
-            if len(done) > 0:
-                waiting = False
-                break
+                # Same id, different payload: not ours.
+                if (
+                    match_value is not None
+                    and _cc_cmd_field(row, match_column) != match_value
+                ):
+                    continue
 
-        if timeout and counter > int(timeout / poll_rate):
+                seen = True
+
+                if int(_cc_cmd_field(row, "responses") or 0) > 0:
+                    return
+
+        now = time.monotonic()
+        elapsed = now - start
+
+        if not seen and now >= appear_deadline:
             raise RuntimeError(
-                f"Timeout exceeded in mm_wait_for_command (timeout={timeout}, counter={counter}, poll_rate={poll_rate})"
+                f"cc command {cmd_id} never appeared on host {host} within "
+                f"{appear_grace}s; it was most likely created under a different "
+                "namespace"
             ) from None
+
+        if timeout and now >= deadline:
+            raise RuntimeError(
+                f"timed out after {elapsed:.1f}s waiting for cc command "
+                f"{cmd_id} (timeout={timeout})"
+            ) from None
+
+        if client and now >= next_check:
+            next_check = now + phenix_settings.CC_LIVENESS_INTERVAL
+
+            if mm_cc_client_seen(mm, client) is not None:
+                last_seen = now
+            elif now - last_seen > client_grace:
+                raise RuntimeError(
+                    f"miniccc client {client} unreachable for "
+                    f"{now - last_seen:.1f}s while waiting for cc command {cmd_id}"
+                )
+
+        if wait_log.due():
+            logger.info(
+                f"waiting for cc command {cmd_id} on {host} (elapsed={elapsed:.1f}s, "
+                f"client={client}, timeout={timeout})"
+            )
 
         if debug:
             print_msg(
-                f"Waiting {poll_rate} seconds before checking command for ID '{cmd_id}' in mm_wait_for_cmd (timeout={timeout}, counter={counter})"
+                f"Waiting {poll_rate} seconds before checking command for ID "
+                f"'{cmd_id}' in mm_wait_for_cmd (timeout={timeout}, "
+                f"elapsed={elapsed:.1f})"
             )
 
         time.sleep(poll_rate)
-        counter += 1
 
 
 def mm_wait_for_prefix(
     mm: minimega.minimega,
     prefix: str,
     num_responses: int,
-    timeout: float = 0.0,
+    timeout: float = phenix_settings.CC_SEND_GRACE,
     poll_rate: float = 1.0,
     debug: bool = False,
 ) -> None:
-    # 'Header': ['id', 'prefix', 'command', 'responses', 'background', 'once', 'sent', 'received', 'connectivity', 'level', 'filter']
-    # 'Tabular': [['1', 'testing', '[/usr/bin/iperf3 --version]', '15', 'false', 'true', '[]', '[]', '', '', 'os=linux && iperf=1']]
-    def last_test(c):
-        return c[1] == prefix
+    """Block until ``num_responses`` responses have arrived on all hosts for
+    commands matching the prefix."""
+    start = time.monotonic()
+    deadline = start + timeout
+    wait_log = _WaitLog()
 
-    def done_test(c):
-        return int(c[3]) == num_responses
+    while True:
+        # 'Header': ['id', 'prefix', 'command', 'responses', 'background', 'once', 'sent', 'received', 'connectivity', 'level', 'filter']
+        # 'Tabular': [['1', 'testing', '[/usr/bin/iperf3 --version]', '15', 'false', 'true', '[]', '[]', '', '', 'os=linux && iperf=1']]
+        seen = 0
 
-    waiting = True
-    counter = 0
+        for resp in mm_cc_all_hosts(mm, mm.cc_commands):
+            for row in resp.get("Tabular") or []:
+                if _cc_cmd_field(row, "prefix") != prefix:
+                    continue
 
-    while waiting:
-        commands = mm.cc_commands()
+                seen += int(_cc_cmd_field(row, "responses") or 0)
 
-        for host in commands:
-            last = list(filter(last_test, host["Tabular"]))
-            done = list(filter(done_test, last))
+        if seen >= num_responses:
+            return
 
-            if len(done) > 0:
-                waiting = False
-                break
+        now = time.monotonic()
+        elapsed = now - start
 
-        if timeout and counter > int(timeout / poll_rate):
+        if timeout and now >= deadline:
             raise RuntimeError(
-                f"Timeout exceeded in mm_wait_for_prefix (timeout={timeout}, counter={counter}, poll_rate={poll_rate})"
+                f"timed out after {elapsed:.1f}s waiting for {num_responses} cc "
+                f"responses with prefix '{prefix}' (timeout={timeout})"
             ) from None
+
+        if wait_log.due():
+            logger.info(
+                f"waiting for cc commands with prefix '{prefix}' "
+                f"(elapsed={elapsed:.1f}s, timeout={timeout})"
+            )
 
         if debug:
             print_msg(
-                f"Waiting {poll_rate} seconds before checking command for prefix '{prefix}' in mm_wait_for_prefix (timeout={timeout}, counter={counter})"
+                f"Waiting {poll_rate} seconds before checking command for prefix "
+                f"'{prefix}' in mm_wait_for_prefix (timeout={timeout}, "
+                f"elapsed={elapsed:.1f})"
             )
 
         time.sleep(poll_rate)
-        counter += 1
 
 
 def mm_get_cc_responses(mm: minimega.minimega, id_or_prefix_or_all: str) -> list[dict]:
@@ -646,8 +898,9 @@ def mm_get_cc_responses(mm: minimega.minimega, id_or_prefix_or_all: str) -> list
         if not row["Response"]:
             continue
 
+        # \d+, not \d: a single digit truncates ids >= 10.
         cmd_resps = re.findall(
-            r"(\d)/(\w+-\w+-\w+-\w+-\w+)/(.*?)/", row["Response"], re.DOTALL
+            r"(\d+)/(\w+-\w+-\w+-\w+-\w+)/(.*?)/", row["Response"], re.DOTALL
         )
 
         for cmd_resp in cmd_resps:
@@ -668,9 +921,10 @@ def mm_get_cc_responses(mm: minimega.minimega, id_or_prefix_or_all: str) -> list
             if "stderr:\n" not in output and "stdout:\n" not in output:
                 print_msg(f"WARNING: no stderr or stdout in response: {output!r}")
 
-            # Fetch the exit code by UUID, polling through transient multi-host
-            # "no client" blips rather than a single blind retry.
-            exit_resp = mm_cc_exitcode_wait(mm, cmd_result["id"], cmd_result["uuid"])
+            # The id came from this host's response, so scope the lookup to it.
+            exit_resp = mm_cc_exitcode_wait(
+                mm, cmd_result["id"], cmd_result["uuid"], host=row.get("Host")
+            )
             cmd_result["exitcode"] = int(exit_resp["Response"])
 
             results.append(cmd_result)
@@ -704,12 +958,19 @@ def mm_last_command(mm: minimega.minimega) -> dict:
 
 
 def mm_vm_uuid(mm: minimega.minimega, name: str) -> str | None:
-    info = mm.vm_info(summary="summary")
+    """UUID of VM ``name``, or None. Exact match -- minimega preserves the
+    launched case."""
+    for host in mm_cc_all_hosts(mm, mm.vm_info, summary="summary"):
+        header = host.get("Header") or []
 
-    for host in info:
-        for vm in host["Tabular"]:
-            if vm[1] == name:
-                return vm[4]
+        if "name" not in header or "uuid" not in header:
+            continue
+
+        name_idx, uuid_idx = header.index("name"), header.index("uuid")
+
+        for vm in host.get("Tabular") or []:
+            if max(name_idx, uuid_idx) < len(vm) and vm[name_idx] == name:
+                return vm[uuid_idx]
 
     return None
 
@@ -722,12 +983,23 @@ def mm_vm_info(mm: minimega.minimega) -> dict:
     """
     Returns information on VMs in the current minimega namespace.
     """
-    responses = mm.vm_info()
+    # One response per host on a mesh, each with only its own VMs -- merge them.
+    responses = mm_cc_all_hosts(mm, mm.vm_info)
 
-    if len(responses) > 1:
-        raise ValueError(
-            f"Got {len(responses)} responses from 'mm vm info', expected 1 response"
-        )
+    info: dict = {}
+    data: dict = {}
+
+    for resp in responses:
+        if resp.get("Error"):
+            continue
+
+        header = resp.get("Header") or []
+
+        for item in resp.get("Tabular") or []:
+            info[item[header.index("name")]] = dict(zip(header, item, strict=False))
+
+        for entry in resp.get("Data") or []:
+            data[entry["Name"]] = entry
 
     # Headers: ['id', 'name', 'state', 'uptime', 'type', 'uuid', 'cc_active', 'pid', 'vlan', 'bridge', 'tap', 'mac', 'ip', 'ip6', 'qos', 'qinq', 'bond', 'memory', 'vcpus', 'disks', 'snapshot', 'initrd', 'kernel', 'cdrom', 'migrate', 'append', 'serial-ports', 'virtio-ports', 'vnc_port', 'usb-use-xhci', 'tpm-socket', 'filesystem', 'hostname', 'init', 'preinit', 'fifo', 'volume', 'console_port', 'tags']
 
@@ -735,12 +1007,9 @@ def mm_vm_info(mm: minimega.minimega) -> dict:
 
     return {
         # Results from "mm vm info", keyed by VM name
-        "info": {
-            item[1]: dict(zip(responses[0]["Header"], item, strict=False))
-            for item in responses[0]["Tabular"]
-        },
+        "info": info,
         # Metadata about VMs, keyed by VM name
-        "data": {data["Name"]: data for data in responses[0]["Data"]},
+        "data": data,
     }
 
 

--- a/src/python/phenix_apps/testing/README.md
+++ b/src/python/phenix_apps/testing/README.md
@@ -16,6 +16,7 @@ or `-p` flag is needed.
 import pytest
 from phenix_apps.apps.myapp.app import MyApp
 
+
 @pytest.mark.app_class(cls=MyApp)
 def test_does_thing(mock_app):
     mock_app.do_thing("host1")
@@ -34,7 +35,9 @@ from phenix_apps.apps.myapp.app import MyApp
 
 pytestmark = pytest.mark.app_class(cls=MyApp, name="myapp")
 
+
 def test_one(mock_app): ...
+
 
 def test_two(mock_app): ...
 ```


### PR DESCRIPTION
# fix(mm): add additional checks and safety

## Description
  * cc command ids are per-host; resolve and scope every id lookup to the host owning the target client.
  * Match and filter cc clients by UUID.
  * Command waits are unbounded but supervised by client liveness; only the command's appearance on its host is time-bounded.
  * Merge per-host responses in mm_vm_info and mm_wait_for_prefix, neither of which could be satisfied on a mesh.
  * Parse multi-digit cc command ids; `(\d)` truncated every id >= 10.
  * Carry minimega's errors into the exit-code timeout.
  * Move cc settings to common/settings.py and document them in phenix-docs.

`mm_command_id` and `mm_cc_client_active` are deprecated in favour of
`mm_command_id_for_host` and `mm_cc_client_locate`, which report the owning host.

## Related Issue
Follow-up to #110 / [sceptre-phenix#313](https://github.com/sandialabs/sceptre-phenix/pull/313).
Pairs with [sceptre-phenix#334](https://github.com/sandialabs/sceptre-phenix/pull/334).
Pairs with [sandia-minimega/minimega#1618](https://github.com/sandia-minimega/minimega/pull/1618)
Docs https://github.com/sandialabs/sceptre-phenix-docs/pull/46

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
AI generated, human reviewed and tested.


