### PR TITLE
fix(sceptre): fep config fix

### DIFF
--- a/src/python/app_migration_guide.md
+++ b/src/python/app_migration_guide.md
@@ -21,15 +21,19 @@ import argparse
 import sys
 from .app import MyApp
 
+
 def main():
     parser = argparse.ArgumentParser(description="phenix user app: my-app")
-    parser.add_argument("stage", choices=["configure", "pre-start", ...], help="Lifecycle stage")
+    parser.add_argument(
+        "stage", choices=["configure", "pre-start", ...], help="Lifecycle stage"
+    )
     parser.add_argument("--dry-run", action="store_true", help="Perform a dry run")
     args = parser.parse_args()
 
     app = MyApp(args.stage, args.dry_run)
     app.execute_stage()
     print(app.experiment.to_json())
+
 
 if __name__ == "__main__":
     main()
@@ -43,8 +47,10 @@ Update the file to call the new `AppBase.main()` class method, passing the app's
 # new __main__.py
 from .app import MyApp
 
+
 def main():
     MyApp.main("my-app-name")
+
 
 if __name__ == "__main__":
     main()
@@ -64,6 +70,7 @@ import sys
 from box import Box
 from phenix_apps.apps import AppBase
 
+
 class MyApp(AppBase):
     def __init__(self, stage, dryrun=False):
         self.raw_input = sys.stdin.read()
@@ -80,6 +87,7 @@ The new constructor is much cleaner. It accepts `name`, `stage`, and `dryrun` an
 ```python
 # new app.py
 from phenix_apps.apps import AppBase
+
 
 class MyApp(AppBase):
     def __init__(self, name, stage, dryrun=False):

--- a/src/python/phenix_apps/apps/scale/README.md
+++ b/src/python/phenix_apps/apps/scale/README.md
@@ -241,6 +241,7 @@ External plugins allow you to extend the Scale app without modifying the core co
 from phenix_apps.apps.scale.interface import ScalePlugin
 from phenix_apps.apps.scale.registry import register_plugin
 
+
 @register_plugin("my-external-plugin")
 class MyExternalPlugin(ScalePlugin):
     # ... implement abstract methods ...

--- a/src/python/phenix_apps/apps/sceptre/app.py
+++ b/src/python/phenix_apps/apps/sceptre/app.py
@@ -1140,6 +1140,7 @@ class Sceptre(AppBase):
             pub_endpoint = provider.metadata.get(
                 "publish_endpoint", "udp://*;239.0.0.1:40000"
             )
+            subtype = fd_.metadata.get("subtype", "single")
 
             fd_interfaces = {}
             for _, iface in enumerate(fd_.topology.network.interfaces):
@@ -1221,6 +1222,7 @@ class Sceptre(AppBase):
                 devices_by_protocol=parsed.devices_by_protocol,
                 publish_endpoint=pub_endpoint,
                 server_endpoint=srv_endpoint,
+                device_subtype=subtype,
                 reg_config=reg_config,
                 counter=fep_counter,
             )

--- a/src/python/phenix_apps/testing/README.md
+++ b/src/python/phenix_apps/testing/README.md
@@ -16,6 +16,7 @@ or `-p` flag is needed.
 import pytest
 from phenix_apps.apps.myapp.app import MyApp
 
+
 @pytest.mark.app_class(cls=MyApp)
 def test_does_thing(mock_app):
     mock_app.do_thing("host1")
@@ -34,7 +35,9 @@ from phenix_apps.apps.myapp.app import MyApp
 
 pytestmark = pytest.mark.app_class(cls=MyApp, name="myapp")
 
+
 def test_one(mock_app): ...
+
 
 def test_two(mock_app): ...
 ```


### PR DESCRIPTION
FEP Config fix

## Description
The SCEPTRE app is currently broken for any field-device defined as a `fep`. The `FieldDeviceConfig` class requires a `device_subtype` field, but the fep config doesn't pass one. This fix uses the same structure for `device_subtype` as `fd-server`.  https://github.com/sandialabs/sceptre-phenix-apps/blob/main/src/python/phenix_apps/apps/sceptre/configs/configs.py#L57

## Related Issue
NA

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
NA