### PR TITLE
feat(sceptre): logic scratch variables become internal tags (rebase of #106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SCEPTRE App**: Pre-flight scenario validation: one pydantic model, run before either stage, reporting every problem at once with the host and field.
 - **SCEPTRE App**: Stage accounting in the logs: a scenario inventory by device type, and what each handler produced.
 - **SCEPTRE App**: Files in `<assetDir>/injects/override/` that match no injection are reported as probable typos.
+- **SCEPTRE App**: `metadata.logic` scratch variables become `<internal-tag>`s on fd-servers and feps; feps now honour `metadata.logic`. (#106)
 - **SCEPTRE App**: Test suite (128 tests), two of them characterization tests over both stages and all 310 infrastructure/device-type/protocol combinations, plus `apps/sceptre/README.md`.
 
 ### Changed

--- a/src/python/phenix_apps/apps/sceptre/field_devices.py
+++ b/src/python/phenix_apps/apps/sceptre/field_devices.py
@@ -38,6 +38,35 @@ ALWAYS_REPORTED: Final[tuple[str, ...]] = (
     "2404-local",
 )
 
+INPUT_REGS: Final[frozenset[str]] = frozenset(
+    {"analog-input", "binary-input", "input-register", "discrete-input"}
+)
+
+
+def internal_tags(logic: str | None, *fd_configs) -> dict[str, float]:
+    """Logic targets (``lhs = rhs;``) that are not an output register.
+
+    These are scratch variables the device must declare as ``<internal-tag>``.
+    0.0 is bennu's initial state, valid as both analog and (false) binary.
+    """
+    if not logic:
+        return {}
+    outputs = {
+        f"{reg.devname}.{reg.field}"
+        for fd_config in fd_configs
+        for protocol in fd_config.protocols
+        for device in protocol.devices
+        for reg in device.registers
+        if reg.regtype not in INPUT_REGS
+    }
+    tags = {}
+    for line in logic.split(";"):
+        name, sep, _ = line.partition("=")
+        name = name.strip()
+        if sep and name and name not in outputs:
+            tags[name] = 0.0
+    return tags
+
 
 class FieldDevices(PreStartState):
     """fd-server, fd-client and fep handling."""
@@ -165,6 +194,7 @@ class FieldDevices(PreStartState):
                     fd_config=fd_config,
                     logic=fd_logic,
                     cycle_time=fd_cycle_time,
+                    internal_tags=internal_tags(fd_logic, fd_config),
                 )
 
             self.app.render_sceptre_start(
@@ -311,6 +341,7 @@ class FieldDevices(PreStartState):
             )
             self.fd_server_configs[fep_config.name] = fep_config
 
+            fep_logic = fd_.metadata.get("logic", None)
             self.render(
                 "fep_template.mako",
                 fd_directory / "config.xml",
@@ -318,6 +349,8 @@ class FieldDevices(PreStartState):
                 command_endpoint=cmd_ip,
                 name=fd_.hostname,
                 fep_config=fep_config,
+                logic=fep_logic,
+                internal_tags=internal_tags(fep_logic, *server_configs),
             )
 
             self.app.render_sceptre_start(fd_, name="field-device")

--- a/src/python/phenix_apps/apps/sceptre/templates/fd_server.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/fd_server.mako
@@ -36,6 +36,12 @@ def intercambio(dictionary, string):
         % endfor
     % endfor
 % endfor
+% for tag, value in internal_tags.items():
+            <internal-tag>
+                <name>${tag}</name>
+                <value>${value}</value>
+            </internal-tag>
+% endfor
         </tags>
         <comms>
 % for protocol in fd_config.protocols:

--- a/src/python/phenix_apps/apps/sceptre/templates/fep_template.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/fep_template.mako
@@ -85,6 +85,12 @@ sunspec_register = ''
         % endfor
     % endfor
 % endfor
+% for tag, value in internal_tags.items():
+            <internal-tag>
+                <name>${tag}</name>
+                <value>${value}</value>
+            </internal-tag>
+% endfor
         </tags>
 
     <comms>
@@ -384,7 +390,7 @@ mapa_nombre_salida = {}
                         output_name = fd_config.name+'_'+'O'+str(register.addr)
                     binary_regs = ['binary-input', 'binary-output',
                                    'discrete-input', 'coil']
-                    mapa_nombre_salida[register.devname+'.'+register.field] = 'var_'+io_name
+                    mapa_nombre_salida[register.devname+'.'+register.field] = 'var_'+output_name
                     %>
                     % if register.regtype in binary_regs:
                 <binary>

--- a/src/python/phenix_apps/apps/sceptre/tests/test_prestart.py
+++ b/src/python/phenix_apps/apps/sceptre/tests/test_prestart.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from phenix_apps.apps.sceptre.app import Sceptre
+from phenix_apps.apps.sceptre.field_devices import internal_tags
 from phenix_apps.apps.sceptre.prestart import PreStart
 from phenix_apps.apps.sceptre.tests.conftest import iface, node
 
@@ -175,6 +176,33 @@ class TestRegisterOverrides:
         assert analog == ["voltage"]
 
 
+def render_kwargs(sceptre_app, template):
+    """The kwargs of the one render call for `template`."""
+    calls = [c for c in sceptre_app.render.call_args_list if c.args[0] == template]
+    assert len(calls) == 1
+    return calls[0].kwargs
+
+
+class TestInternalTags:
+    """Logic scratch variables become <internal-tag>s; output targets do not."""
+
+    LOGIC = "bus-rtu-1.active = bus-rtu-1.gen_mw > 1; tmp = 2;  = 3; noassign"
+
+    def test_only_non_output_targets(self, sceptre_app, ctx_with_provider):
+        sceptre_app.extract_nodes_type.return_value = [
+            fd_server("rtu-1", [iface("IF0", "10.2.0.11")], logic=self.LOGIC)
+        ]
+
+        ctx_with_provider.fd_servers()
+
+        kwargs = render_kwargs(sceptre_app, "fd_server.mako")
+        assert kwargs["logic"] == self.LOGIC
+        assert kwargs["internal_tags"] == {"tmp": 0.0}
+
+    def test_no_logic_means_no_tags(self):
+        assert internal_tags(None) == internal_tags("") == {}
+
+
 class TestFeps:
     """A fep fronts the fd-servers it adopts, and takes their devices with it."""
 
@@ -210,6 +238,18 @@ class TestFeps:
         assert [d.device_name for p in config.protocols for d in p.devices] == [
             "bus-rtu-1"
         ]
+
+    def test_logic_targets_the_adopted_rtu_outputs(
+        self, sceptre_app, ctx_with_provider
+    ):
+        """The fep's logic writes the RTUs' outputs, so those are not internal."""
+
+        logic = "bus-rtu-1.active = 1; scratch = 0"
+        self.build(sceptre_app, ctx_with_provider, {"logic": logic})
+
+        kwargs = render_kwargs(sceptre_app, "fep_template.mako")
+        assert kwargs["logic"] == logic
+        assert kwargs["internal_tags"] == {"scratch": 0.0}
 
     def test_subtype_reaches_the_config(self, sceptre_app, ctx_with_provider):
         """Omitting it used to raise TypeError, so no fep could be built."""


### PR DESCRIPTION
# feat(sceptre): logic scratch variables become internal tags

## Description
Rebase of #106 (@mgaliar) onto split app from #127. `metadata.logic` assignment whose target is not an output register (`devname.field`) is scratch variable — emitted as `<internal-tag>` initialised to `0.0`, on fd-servers and feps.

Differences from #106:
- One helper, `field_devices.internal_tags(logic, *configs)`, not two inline copies.
- #106 fep branch reused `fd_logic`/`fd_config` leaked from last fd-server loop iteration, and passed `internal_tags=` kwarg `FieldDeviceConfig.__init__` rejects (`TypeError`). Here fep derives outputs from its adopted RTUs' configs.
- `metadata.logic` now actually reaches `fep_template.mako` (its `<logic>` block was never rendered); output-name map uses `output_name`, not stale `io_name`.
- Empty assignment targets (`= 3`) skipped, not emitted as `""` tag.

Verified: golden scenario with `logic` on `rtu-3` + `fep-1` renders expected `<internal-tag>` and `<logic>` blocks. Golden files unchanged (golden input has no `logic`).

## Related Issue
Supersedes #106.

## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
@mgaliar please check fep semantics: assumed fep logic writes the adopted RTUs' outputs (what the template's `<output>` block emits). If the fep's own `dnp3:` devices should also count as outputs, it's a one-arg change to the `internal_tags(...)` call.
