### PR TITLE
fix(sceptre): stop later PowerWorld providers clobbering hil_tags and objects.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SCEPTRE App**: The `reg_config` manual register-map path. It was dead code: the app never populated it, so every device always took the automatic numbering branch. Output is unchanged.
 
 ### Fixed
+- **SCEPTRE App**: With more than one PowerWorld provider, only the last one's `hil_tags` reached the object list, and only the last one's `objects.txt` was written. Tags now aggregate across providers and every PowerWorld provider gets the combined `objects.txt`.
 - **SCEPTRE App**: Every `sunspec` inverter raised `KeyError`: the SunSpec register mappings are keyed `PowerDistribution` but received `power-distribution`. The whole protocol was unusable.
 - **SCEPTRE App**: `fep` hosts raised `TypeError`, built without the required `device_subtype`.
 - **SCEPTRE App**: Per-device register overrides raised `RuntimeError` in `SceptreMetadataParser`, which popped keys while iterating a live dict view.

--- a/src/python/phenix_apps/apps/sceptre/prestart.py
+++ b/src/python/phenix_apps/apps/sceptre/prestart.py
@@ -118,12 +118,13 @@ class PreStart(FieldDevices, Scada, Stage):
     def provider_configs(self) -> None:
         """Render each provider's config.ini and startup script.
 
-        Writes: hil_object_list, objects_file_path, provider_hosts, provider_map
+        Writes: hil_object_list, objects_file_paths, provider_hosts, provider_map
         """
 
         self.provider_hosts = self.hosts("provider")
         self.provider_map = {}
-        self.objects_file_path = None
+        self.objects_file_paths = []
+        self.hil_object_list = []
 
         # an ignition hmi needs the provider to sleep first
         needsleep = bool(self.labelled("ignition"))
@@ -190,17 +191,18 @@ class PreStart(FieldDevices, Scada, Stage):
             )
 
     def power_objects(self) -> None:
-        """Write the combined power object list for a PowerWorld provider.
+        """Write the combined power object list for each PowerWorld provider.
 
-        Reads: hil_object_list, objects_file_path, power_object_list
+        Reads: hil_object_list, objects_file_paths, power_object_list
         Writes: power_object_list
         """
 
-        if self.objects_file_path:
+        if self.objects_file_paths:
             self.power_object_list = unique(
                 self.power_object_list + self.hil_object_list
             )
-            Path(self.objects_file_path).write_text("\n".join(self.power_object_list))
+        for path in self.objects_file_paths:
+            Path(path).write_text("\n".join(self.power_object_list))
 
     def register_topics(self, name: str, helics_provider: bool) -> dict:
         """subs/pubs/ends derived from every field device register.

--- a/src/python/phenix_apps/apps/sceptre/simulators.py
+++ b/src/python/phenix_apps/apps/sceptre/simulators.py
@@ -93,8 +93,10 @@ def power_world_kwargs(
 ) -> ProviderConfig:
     """Shared by the whole POWER_WORLD_FAMILY, PowerWorldDynamics included."""
 
-    stage.objects_file_path = str(provider_directory / "objects.txt")
-    stage.hil_object_list = provider.metadata.get("hil_tags", [])
+    # Append, don't assign: with several PowerWorld providers every one gets an
+    # objects.txt, and hil_tags from all of them reach the combined list.
+    stage.objects_file_paths.append(str(provider_directory / "objects.txt"))
+    stage.hil_object_list.extend(provider.metadata.get("hil_tags", []))
     return {"case_file": "case.PWB", "oneline_file": "oneline.pwd"}
 
 

--- a/src/python/phenix_apps/apps/sceptre/stages.py
+++ b/src/python/phenix_apps/apps/sceptre/stages.py
@@ -95,7 +95,7 @@ class PreStartState(Stage):
         self.provider_hosts: list[Box] = []
 
         # Only a PowerWorld provider sets a path to write objects to.
-        self.objects_file_path: str | None = None
+        self.objects_file_paths: list[str] = []
         self.hil_object_list: list[str] = []
         self.power_object_list: list[str] = []
 

--- a/src/python/phenix_apps/apps/sceptre/tests/sceptre_golden.json
+++ b/src/python/phenix_apps/apps/sceptre/tests/sceptre_golden.json
@@ -30,6 +30,19 @@
                   }
                 },
                 {
+                  "hostname": "provider-pw2",
+                  "metadata": {
+                    "case": "/phenix/topologies/golden/case2.PWB",
+                    "hil_tags": [
+                      "hil-bus-9.voltage",
+                      "hil-line-2.current"
+                    ],
+                    "oneline": "/phenix/topologies/golden/oneline2.pwd",
+                    "simulator": "PowerWorld",
+                    "type": "provider"
+                  }
+                },
+                {
                   "hostname": "provider-pp",
                   "metadata": {
                     "case": "/phenix/topologies/golden/case.py",
@@ -332,6 +345,59 @@
                   },
                   {
                     "address": "10.2.0.10",
+                    "mask": 24,
+                    "name": "IF1",
+                    "type": "ethernet",
+                    "vlan": "field"
+                  }
+                ]
+              }
+            },
+            {
+              "general": {
+                "hostname": "provider-pw2"
+              },
+              "hardware": {
+                "os_type": "windows"
+              },
+              "injections": [
+                {
+                  "description": "PowerWorld config",
+                  "dst": "sceptre/config.ini",
+                  "src": "{BASE_DIR}/sceptre/provider-pw2/config.ini"
+                },
+                {
+                  "description": "PowerWorld objects",
+                  "dst": "sceptre/objects.txt",
+                  "src": "{BASE_DIR}/sceptre/provider-pw2/objects.txt"
+                },
+                {
+                  "description": "PowerWorld binary file",
+                  "dst": "sceptre/case.PWB",
+                  "src": "/phenix/topologies/golden/case2.PWB"
+                },
+                {
+                  "description": "PowerWorld display file",
+                  "dst": "sceptre/oneline.pwd",
+                  "src": "/phenix/topologies/golden/oneline2.pwd"
+                },
+                {
+                  "description": "provider_startup_scripts",
+                  "dst": "phenix/startup/30-sceptre-start.ps1",
+                  "src": "{BASE_DIR}/startup/provider-pw2-start.ps1"
+                }
+              ],
+              "network": {
+                "interfaces": [
+                  {
+                    "address": "172.16.0.14",
+                    "mask": 16,
+                    "name": "IF0",
+                    "type": "ethernet",
+                    "vlan": "MGMT"
+                  },
+                  {
+                    "address": "10.2.0.14",
                     "mask": 24,
                     "name": "IF1",
                     "type": "ethernet",
@@ -1275,6 +1341,19 @@
                   }
                 },
                 {
+                  "hostname": "provider-pw2",
+                  "metadata": {
+                    "case": "/phenix/topologies/golden/case2.PWB",
+                    "hil_tags": [
+                      "hil-bus-9.voltage",
+                      "hil-line-2.current"
+                    ],
+                    "oneline": "/phenix/topologies/golden/oneline2.pwd",
+                    "simulator": "PowerWorld",
+                    "type": "provider"
+                  }
+                },
+                {
                   "hostname": "provider-pp",
                   "metadata": {
                     "case": "/phenix/topologies/golden/case.py",
@@ -1577,6 +1656,59 @@
                   },
                   {
                     "address": "10.2.0.10",
+                    "mask": 24,
+                    "name": "IF1",
+                    "type": "ethernet",
+                    "vlan": "field"
+                  }
+                ]
+              }
+            },
+            {
+              "general": {
+                "hostname": "provider-pw2"
+              },
+              "hardware": {
+                "os_type": "windows"
+              },
+              "injections": [
+                {
+                  "description": "PowerWorld config",
+                  "dst": "sceptre/config.ini",
+                  "src": "{BASE_DIR}/sceptre/provider-pw2/config.ini"
+                },
+                {
+                  "description": "PowerWorld objects",
+                  "dst": "sceptre/objects.txt",
+                  "src": "{BASE_DIR}/sceptre/provider-pw2/objects.txt"
+                },
+                {
+                  "description": "PowerWorld binary file",
+                  "dst": "sceptre/case.PWB",
+                  "src": "/phenix/topologies/golden/case2.PWB"
+                },
+                {
+                  "description": "PowerWorld display file",
+                  "dst": "sceptre/oneline.pwd",
+                  "src": "/phenix/topologies/golden/oneline2.pwd"
+                },
+                {
+                  "description": "provider_startup_scripts",
+                  "dst": "phenix/startup/30-sceptre-start.ps1",
+                  "src": "{BASE_DIR}/startup/provider-pw2-start.ps1"
+                }
+              ],
+              "network": {
+                "interfaces": [
+                  {
+                    "address": "172.16.0.14",
+                    "mask": 16,
+                    "name": "IF0",
+                    "type": "ethernet",
+                    "vlan": "MGMT"
+                  },
+                  {
+                    "address": "10.2.0.14",
                     "mask": 24,
                     "name": "IF1",
                     "type": "ethernet",
@@ -2508,7 +2640,9 @@
       "sceptre/provider-pp/config.ini": "453336b18c48792b87baf5b3dbd95cb293aa039435256bbf37522b7a5e2da2fa",
       "sceptre/provider-pp/helics.json": "409221c7a256e9a101b0094f85c69c943096d4d02ae0bcf658aade05ed8a7634",
       "sceptre/provider-pw/config.ini": "b2043f396a69f09e3cc58346e7a73f168fc50597040b0db228edab199d0bd6a1",
-      "sceptre/provider-pw/objects.txt": "b4ca885b13f095ed5d03c77192906bbb9b267b237abdfaca6cfed9fbdb5cc736",
+      "sceptre/provider-pw/objects.txt": "07c0fec4f15314f12e77110caafaba2768153da8cdb88af9efb26155ac2bd483",
+      "sceptre/provider-pw2/config.ini": "ecd08893debbb1b370391d577b0e3a5855871872cf547316142430e53d9ea767",
+      "sceptre/provider-pw2/objects.txt": "07c0fec4f15314f12e77110caafaba2768153da8cdb88af9efb26155ac2bd483",
       "sceptre/provider-rtds/config.ini": "5cad195ee1b8aab37b602b8a13544ac610eb5fbacc4345d9f990242fc9b12d5f",
       "sceptre/provider-rtds/rtds_config.yaml": "56cd0f1f580ddb3c5d82371e4813747c9e9e07249576c6cc8d92c928b2df60b9",
       "sceptre/provider-sim/config.ini": "25a5a8e94b02f65e2c582a3e22051bb5c9bb7d1bb960bffaaf4c2da8ae96783d",
@@ -2578,6 +2712,7 @@
       "startup/helics-broker-1-helics.sh": "0de248c2b918bbce674fe114b4d051759fe3a30116ebb5d648cfffc0428490c6",
       "startup/provider-pp-start.sh": "e868ec95b313ced8bbddb30b73cde23a966265fbb24ef34f78265297be814c10",
       "startup/provider-pw-start.ps1": "48a44e9ae3efb74ace2ccdd9267f457e7e871c7c2282bd18ecf49b3f5433f595",
+      "startup/provider-pw2-start.ps1": "48a44e9ae3efb74ace2ccdd9267f457e7e871c7c2282bd18ecf49b3f5433f595",
       "startup/provider-rtds-start.sh": "0826e4f39d5581aca2c1a0bfa584ad9eae3a095d19c59e2e5695faf47d3a8adb",
       "startup/provider-sim-start.sh": "f8d9d6638776b895686a3acd9e6d678eb8670952e80c87006ce657f8d4ac900d",
       "startup/rtu-1-start.sh": "f8c77b3f4e99563d9f2568f9edd73312aac1b49ef4c9e0a119a47b5ad656c04e",

--- a/src/python/phenix_apps/apps/sceptre/tests/test_prestart.py
+++ b/src/python/phenix_apps/apps/sceptre/tests/test_prestart.py
@@ -296,13 +296,37 @@ class TestWritePowerObjects:
     def test_merges_hil_tags_deduplicates_and_sorts(self, sceptre_app, tmp_path):
         objects = tmp_path / "objects.txt"
         ctx = PreStart(sceptre_app)
-        ctx.objects_file_path = str(objects)
+        ctx.objects_file_paths = [str(objects)]
         ctx.power_object_list = ["gen-2", "bus-1", "gen-2"]
         ctx.hil_object_list = ["hil-9", "bus-1"]
 
         ctx.power_objects()
 
         assert objects.read_text().split("\n") == ["bus-1", "gen-2", "hil-9"]
+
+    def test_every_powerworld_provider_gets_the_objects_file(
+        self, sceptre_app, tmp_path
+    ):
+        """Two providers: both objects.txt written, hil_tags from both merged.
+
+        Previously the second provider's path and hil_tags overwrote the
+        first's, so only the last objects.txt existed and only its tags
+        survived.
+        """
+        first = tmp_path / "pw-1" / "objects.txt"
+        second = tmp_path / "pw-2" / "objects.txt"
+        first.parent.mkdir()
+        second.parent.mkdir()
+        ctx = PreStart(sceptre_app)
+        ctx.objects_file_paths = [str(first), str(second)]
+        ctx.power_object_list = ["bus-1"]
+        ctx.hil_object_list = ["hil-1", "hil-2"]
+
+        ctx.power_objects()
+
+        expected = ["bus-1", "hil-1", "hil-2"]
+        assert first.read_text().split("\n") == expected
+        assert second.read_text().split("\n") == expected
 
     def test_writes_nothing_without_a_powerworld_provider(self, sceptre_app, tmp_path):
         ctx = PreStart(sceptre_app)

--- a/src/python/phenix_apps/apps/sceptre/tests/test_sceptre_input.yaml
+++ b/src/python/phenix_apps/apps/sceptre/tests/test_sceptre_input.yaml
@@ -3,7 +3,7 @@
 # Deliberately exercises every branch that the configure and pre-start stages
 # reach, including several that only fire on odd topologies:
 #
-#   - three providers with different simulators: PowerWorld (Windows paths),
+#   - providers with different simulators: two PowerWorld (Windows paths),
 #     PyPower, and Simulink with ground truth (the solver/publish-points/gt
 #     injections, which no other host exercises)
 #   - fd-servers on both dnp3 and modbus, plus a serial interface
@@ -46,6 +46,19 @@ spec:
               hil_tags:
                 - hil-bus-9.voltage
               debug: true
+
+          # Second PowerWorld provider: pins that hil_tags aggregate across
+          # providers and that every PowerWorld provider gets an objects.txt
+          # (each used to be overwritten by the last provider seen).
+          - hostname: provider-pw2
+            metadata:
+              type: provider
+              simulator: PowerWorld
+              case: /phenix/topologies/golden/case2.PWB
+              oneline: /phenix/topologies/golden/oneline2.pwd
+              hil_tags:
+                - hil-bus-9.voltage
+                - hil-line-2.current
 
           - hostname: provider-pp
             metadata:
@@ -224,6 +237,13 @@ spec:
           interfaces:
             - {name: IF0, type: ethernet, vlan: MGMT, address: 172.16.0.10, mask: 16}
             - {name: IF1, type: ethernet, vlan: field, address: 10.2.0.10, mask: 24}
+
+      - general: {hostname: provider-pw2}
+        hardware: {os_type: windows}
+        network:
+          interfaces:
+            - {name: IF0, type: ethernet, vlan: MGMT, address: 172.16.0.14, mask: 16}
+            - {name: IF1, type: ethernet, vlan: field, address: 10.2.0.14, mask: 24}
 
       - general: {hostname: provider-pp}
         hardware: {os_type: linux}


### PR DESCRIPTION
## Description
`power_world_kwargs` assigned `stage.hil_object_list` and `stage.objects_file_path` per provider, so with more than one PowerWorld provider only the last one's `hil_tags` reached the combined object list (while `power_object_list` correctly aggregates across all fd-servers), and only the last provider's `objects.txt` was ever written — the earlier providers' injections shipped a missing file.

Fix: `hil_tags` extend a shared list, and every provider's `objects.txt` path is collected; `power_objects()` writes the combined, deduplicated list to each of them. Single-provider output is unchanged — the prestart golden still passes.

Covered end to end: the golden scenario gains a second PowerWorld provider (`provider-pw2`), and the regenerated golden shows both provider directories receiving the same combined `objects.txt` (identical file hashes) with tags from both providers merged and deduplicated. A unit test additionally pins the merge logic.

**Note:** #137 and #138 are merged; this branch is rebased onto `main` and now carries only the fix (7 files, +196/−12).

## Related Issue
Previously stacked on #138 (now merged).

## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.


