### PR TITLE
refactor(sceptre): make register numbering state per-config, not class-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SCEPTRE App**: Test suite (128 tests), two of them characterization tests over both stages and all 310 infrastructure/device-type/protocol combinations, plus `apps/sceptre/README.md`.
 
 ### Changed
+- **SCEPTRE App**: Register numbering state is per `FieldDeviceConfig` instead of class-level mutable state on `Register`; numbering is no longer order-dependent across configs and the test suite runs safely in parallel. Output is unchanged.
 - **SCEPTRE App**: `configure()` and `pre_start()` are stage classes, `ConfigureStage` and `PreStart`, sharing pre-start state through `PreStartState`.
 - **SCEPTRE App**: The device-type table is `configs/infrastructures.yaml`; adding a device type needs no code change.
 - **SCEPTRE App**: Injections are declared with `Sceptre.inject()`, and all of them in the configure stage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SCEPTRE App**: The `reg_config` manual register-map path. It was dead code: the app never populated it, so every device always took the automatic numbering branch. Output is unchanged.
 
 ### Fixed
+- **SCEPTRE App**: With more than one PowerWorld provider, only the last one's `hil_tags` reached the object list, and only the last one's `objects.txt` was written. Tags now aggregate across providers and every PowerWorld provider gets the combined `objects.txt`.
 - **SCEPTRE App**: Every `sunspec` inverter raised `KeyError`: the SunSpec register mappings are keyed `PowerDistribution` but received `power-distribution`. The whole protocol was unusable.
 - **SCEPTRE App**: `fep` hosts raised `TypeError`, built without the required `device_subtype`.
 - **SCEPTRE App**: Per-device register overrides raised `RuntimeError` in `SceptreMetadataParser`, which popped keys while iterating a live dict view.

--- a/src/python/phenix_apps/apps/sceptre/configs/configs.py
+++ b/src/python/phenix_apps/apps/sceptre/configs/configs.py
@@ -55,6 +55,9 @@ def get_fdconfig_class(infrastructure: str) -> type:
             self, devices_by_protocol: dict[str, list[dict[str, Any]]]
         ) -> list[Protocol]:
             protocols_list = []
+            # One numbering state for the whole config: registers of every
+            # device and protocol in it share the address space.
+            addresses = dict(Register.START)
             for protocol in devices_by_protocol.keys():
                 if "serial" in protocol:
                     protocols_list.append(
@@ -63,6 +66,7 @@ def get_fdconfig_class(infrastructure: str) -> type:
                             devices_by_protocol[protocol],
                             type(self),
                             self.serial_dev.pop(0),
+                            addresses,
                         )
                     )
                 else:
@@ -71,9 +75,9 @@ def get_fdconfig_class(infrastructure: str) -> type:
                             protocol,
                             devices_by_protocol[protocol],
                             type(self),
+                            addresses,
                         )
                     )
-            Register.reset_addresses()
             return protocols_list
 
     return FieldDeviceConfig
@@ -85,12 +89,16 @@ class Protocol:
         protocol: str,
         devices: list[dict[str, Any]],
         infrastructure_class: type,
+        addresses: dict[str, int],
     ) -> None:
         self.protocol = protocol
-        self.devices = self.__generate_devices(devices, infrastructure_class)
+        self.devices = self.__generate_devices(devices, infrastructure_class, addresses)
 
     def __generate_devices(
-        self, devices: list[dict[str, Any]], infrastructure_class: type
+        self,
+        devices: list[dict[str, Any]],
+        infrastructure_class: type,
+        addresses: dict[str, int],
     ) -> list[Device]:
         devices_list = []
         for device in devices:
@@ -101,7 +109,11 @@ class Protocol:
                 kwargs[key] = device[key]
             devices_list.append(
                 infrastructure_class.create_device(
-                    device["type"], device["name"], self.protocol, **kwargs
+                    device["type"],
+                    device["name"],
+                    self.protocol,
+                    addresses=addresses,
+                    **kwargs,
                 )
             )
         return devices_list
@@ -114,9 +126,10 @@ class SerialProtocol(Protocol):
         devices: list[dict[str, Any]],
         infrastructure_class: type,
         serial_dev: str,
+        addresses: dict[str, int],
     ) -> None:
         self.serial_dev = serial_dev
-        super().__init__(protocol, devices, infrastructure_class)
+        super().__init__(protocol, devices, infrastructure_class, addresses)
 
 
 class OpcConfig:

--- a/src/python/phenix_apps/apps/sceptre/configs/infrastructures.py
+++ b/src/python/phenix_apps/apps/sceptre/configs/infrastructures.py
@@ -48,6 +48,7 @@ class Infrastructure:
         device_type: str,
         device_name: str,
         protocol: str,
+        addresses: dict[str, int] | None = None,
         **kwargs: list[str | int],
     ) -> Device:
         """Build one device. AppError if the type is not in the table.
@@ -72,4 +73,5 @@ class Infrastructure:
             fields={f: kwargs.get(f, spec.get(f, [])) for f in FIELD_TYPES},
             range_=spec.get("range", INFRASTRUCTURES[cls.INFRA]["range"]),
             infrastructure=cls.INFRA,
+            addresses=addresses,
         )

--- a/src/python/phenix_apps/apps/sceptre/configs/registers.py
+++ b/src/python/phenix_apps/apps/sceptre/configs/registers.py
@@ -19,6 +19,7 @@ class Device:
         fields: dict[str, list[str | int]],
         range_: tuple[float, float],
         infrastructure: str,
+        addresses: dict[str, int] | None = None,
     ) -> None:
         self.device_type = device_type
         self.device_name = device_name
@@ -27,6 +28,10 @@ class Device:
         self.range = range_
         self.infrastructure = infrastructure
         self.registers = []
+        # Register numbering state. A FieldDeviceConfig passes one shared dict
+        # so numbering runs across all its devices; standalone construction
+        # (tests) gets a fresh one.
+        self.addresses = dict(Register.START) if addresses is None else addresses
         self.__generate_register_list()
 
     def __generate_register_list(self) -> None:
@@ -48,6 +53,7 @@ class Device:
                     self.device_type,
                     self.protocol,
                     self.range,
+                    self.addresses,
                 )
                 for field in fields
             ]
@@ -76,9 +82,8 @@ class Register:
         "iec60870-5-104": ANALOG,
     }
 
-    # Next free address per protocol or register type. Class-level on purpose:
-    # numbering runs across every device in one field device config, and
-    # configs.py resets it between them.
+    # Initial next-free address per protocol or register type; each
+    # FieldDeviceConfig starts numbering from a fresh copy.
     START: ClassVar[dict[str, int]] = {
         "dnp3": 0,
         "dnp3-serial": 0,
@@ -91,7 +96,6 @@ class Register:
         "float-point": 1000,
         "single-point": 3000,
     }
-    addresses: ClassVar[dict[str, int]] = dict(START)
 
     def __init__(
         self,
@@ -101,6 +105,7 @@ class Register:
         devtype: str,
         protocol: str,
         range_: tuple[float, float],
+        addresses: dict[str, int],
     ) -> None:
         self.devname = devname
         self.field = field
@@ -116,12 +121,8 @@ class Register:
             or "bacnet" in self.protocol
             or "iec60870-5-104" in self.protocol
         ):
-            self.addr = type(self).addresses[self.protocol]
-            type(self).addresses[self.protocol] += 1
+            key = self.protocol
         else:
-            self.addr = type(self).addresses[self.regtype]
-            type(self).addresses[self.regtype] += 1
-
-    @staticmethod
-    def reset_addresses() -> None:
-        Register.addresses = dict(Register.START)
+            key = self.regtype
+        self.addr = addresses[key]
+        addresses[key] += 1

--- a/src/python/phenix_apps/apps/sceptre/prestart.py
+++ b/src/python/phenix_apps/apps/sceptre/prestart.py
@@ -118,12 +118,13 @@ class PreStart(FieldDevices, Scada, Stage):
     def provider_configs(self) -> None:
         """Render each provider's config.ini and startup script.
 
-        Writes: hil_object_list, objects_file_path, provider_hosts, provider_map
+        Writes: hil_object_list, objects_file_paths, provider_hosts, provider_map
         """
 
         self.provider_hosts = self.hosts("provider")
         self.provider_map = {}
-        self.objects_file_path = None
+        self.objects_file_paths = []
+        self.hil_object_list = []
 
         # an ignition hmi needs the provider to sleep first
         needsleep = bool(self.labelled("ignition"))
@@ -190,17 +191,18 @@ class PreStart(FieldDevices, Scada, Stage):
             )
 
     def power_objects(self) -> None:
-        """Write the combined power object list for a PowerWorld provider.
+        """Write the combined power object list for each PowerWorld provider.
 
-        Reads: hil_object_list, objects_file_path, power_object_list
+        Reads: hil_object_list, objects_file_paths, power_object_list
         Writes: power_object_list
         """
 
-        if self.objects_file_path:
+        if self.objects_file_paths:
             self.power_object_list = unique(
                 self.power_object_list + self.hil_object_list
             )
-            Path(self.objects_file_path).write_text("\n".join(self.power_object_list))
+        for path in self.objects_file_paths:
+            Path(path).write_text("\n".join(self.power_object_list))
 
     def register_topics(self, name: str, helics_provider: bool) -> dict:
         """subs/pubs/ends derived from every field device register.

--- a/src/python/phenix_apps/apps/sceptre/simulators.py
+++ b/src/python/phenix_apps/apps/sceptre/simulators.py
@@ -93,8 +93,10 @@ def power_world_kwargs(
 ) -> ProviderConfig:
     """Shared by the whole POWER_WORLD_FAMILY, PowerWorldDynamics included."""
 
-    stage.objects_file_path = str(provider_directory / "objects.txt")
-    stage.hil_object_list = provider.metadata.get("hil_tags", [])
+    # Append, don't assign: with several PowerWorld providers every one gets an
+    # objects.txt, and hil_tags from all of them reach the combined list.
+    stage.objects_file_paths.append(str(provider_directory / "objects.txt"))
+    stage.hil_object_list.extend(provider.metadata.get("hil_tags", []))
     return {"case_file": "case.PWB", "oneline_file": "oneline.pwd"}
 
 

--- a/src/python/phenix_apps/apps/sceptre/stages.py
+++ b/src/python/phenix_apps/apps/sceptre/stages.py
@@ -95,7 +95,7 @@ class PreStartState(Stage):
         self.provider_hosts: list[Box] = []
 
         # Only a PowerWorld provider sets a path to write objects to.
-        self.objects_file_path: str | None = None
+        self.objects_file_paths: list[str] = []
         self.hil_object_list: list[str] = []
         self.power_object_list: list[str] = []
 

--- a/src/python/phenix_apps/apps/sceptre/tests/conftest.py
+++ b/src/python/phenix_apps/apps/sceptre/tests/conftest.py
@@ -13,8 +13,6 @@ import pytest
 from box import Box
 from loguru import logger
 
-from phenix_apps.apps.sceptre.configs.registers import Register
-
 
 @pytest.fixture(autouse=True)
 def caplog_loguru_sink(caplog):  # noqa: ARG001
@@ -31,18 +29,6 @@ def caplog_loguru_sink(caplog):  # noqa: ARG001
     handler_id = logger.add(PropagateHandler(), format="{message}")
     yield
     logger.remove(handler_id)
-
-
-@pytest.fixture(autouse=True)
-def _reset_register_addresses():
-    """Register.addresses is class-level mutable state.
-
-    FieldDeviceConfig.__generate_protocols resets it after building each config,
-    but a test that raises part-way through leaves it dirty for the next test.
-    """
-    Register.reset_addresses()
-    yield
-    Register.reset_addresses()
 
 
 @pytest.fixture

--- a/src/python/phenix_apps/apps/sceptre/tests/sceptre_golden.json
+++ b/src/python/phenix_apps/apps/sceptre/tests/sceptre_golden.json
@@ -30,6 +30,19 @@
                   }
                 },
                 {
+                  "hostname": "provider-pw2",
+                  "metadata": {
+                    "case": "/phenix/topologies/golden/case2.PWB",
+                    "hil_tags": [
+                      "hil-bus-9.voltage",
+                      "hil-line-2.current"
+                    ],
+                    "oneline": "/phenix/topologies/golden/oneline2.pwd",
+                    "simulator": "PowerWorld",
+                    "type": "provider"
+                  }
+                },
+                {
                   "hostname": "provider-pp",
                   "metadata": {
                     "case": "/phenix/topologies/golden/case.py",
@@ -332,6 +345,59 @@
                   },
                   {
                     "address": "10.2.0.10",
+                    "mask": 24,
+                    "name": "IF1",
+                    "type": "ethernet",
+                    "vlan": "field"
+                  }
+                ]
+              }
+            },
+            {
+              "general": {
+                "hostname": "provider-pw2"
+              },
+              "hardware": {
+                "os_type": "windows"
+              },
+              "injections": [
+                {
+                  "description": "PowerWorld config",
+                  "dst": "sceptre/config.ini",
+                  "src": "{BASE_DIR}/sceptre/provider-pw2/config.ini"
+                },
+                {
+                  "description": "PowerWorld objects",
+                  "dst": "sceptre/objects.txt",
+                  "src": "{BASE_DIR}/sceptre/provider-pw2/objects.txt"
+                },
+                {
+                  "description": "PowerWorld binary file",
+                  "dst": "sceptre/case.PWB",
+                  "src": "/phenix/topologies/golden/case2.PWB"
+                },
+                {
+                  "description": "PowerWorld display file",
+                  "dst": "sceptre/oneline.pwd",
+                  "src": "/phenix/topologies/golden/oneline2.pwd"
+                },
+                {
+                  "description": "provider_startup_scripts",
+                  "dst": "phenix/startup/30-sceptre-start.ps1",
+                  "src": "{BASE_DIR}/startup/provider-pw2-start.ps1"
+                }
+              ],
+              "network": {
+                "interfaces": [
+                  {
+                    "address": "172.16.0.14",
+                    "mask": 16,
+                    "name": "IF0",
+                    "type": "ethernet",
+                    "vlan": "MGMT"
+                  },
+                  {
+                    "address": "10.2.0.14",
                     "mask": 24,
                     "name": "IF1",
                     "type": "ethernet",
@@ -1275,6 +1341,19 @@
                   }
                 },
                 {
+                  "hostname": "provider-pw2",
+                  "metadata": {
+                    "case": "/phenix/topologies/golden/case2.PWB",
+                    "hil_tags": [
+                      "hil-bus-9.voltage",
+                      "hil-line-2.current"
+                    ],
+                    "oneline": "/phenix/topologies/golden/oneline2.pwd",
+                    "simulator": "PowerWorld",
+                    "type": "provider"
+                  }
+                },
+                {
                   "hostname": "provider-pp",
                   "metadata": {
                     "case": "/phenix/topologies/golden/case.py",
@@ -1577,6 +1656,59 @@
                   },
                   {
                     "address": "10.2.0.10",
+                    "mask": 24,
+                    "name": "IF1",
+                    "type": "ethernet",
+                    "vlan": "field"
+                  }
+                ]
+              }
+            },
+            {
+              "general": {
+                "hostname": "provider-pw2"
+              },
+              "hardware": {
+                "os_type": "windows"
+              },
+              "injections": [
+                {
+                  "description": "PowerWorld config",
+                  "dst": "sceptre/config.ini",
+                  "src": "{BASE_DIR}/sceptre/provider-pw2/config.ini"
+                },
+                {
+                  "description": "PowerWorld objects",
+                  "dst": "sceptre/objects.txt",
+                  "src": "{BASE_DIR}/sceptre/provider-pw2/objects.txt"
+                },
+                {
+                  "description": "PowerWorld binary file",
+                  "dst": "sceptre/case.PWB",
+                  "src": "/phenix/topologies/golden/case2.PWB"
+                },
+                {
+                  "description": "PowerWorld display file",
+                  "dst": "sceptre/oneline.pwd",
+                  "src": "/phenix/topologies/golden/oneline2.pwd"
+                },
+                {
+                  "description": "provider_startup_scripts",
+                  "dst": "phenix/startup/30-sceptre-start.ps1",
+                  "src": "{BASE_DIR}/startup/provider-pw2-start.ps1"
+                }
+              ],
+              "network": {
+                "interfaces": [
+                  {
+                    "address": "172.16.0.14",
+                    "mask": 16,
+                    "name": "IF0",
+                    "type": "ethernet",
+                    "vlan": "MGMT"
+                  },
+                  {
+                    "address": "10.2.0.14",
                     "mask": 24,
                     "name": "IF1",
                     "type": "ethernet",
@@ -2508,7 +2640,9 @@
       "sceptre/provider-pp/config.ini": "453336b18c48792b87baf5b3dbd95cb293aa039435256bbf37522b7a5e2da2fa",
       "sceptre/provider-pp/helics.json": "409221c7a256e9a101b0094f85c69c943096d4d02ae0bcf658aade05ed8a7634",
       "sceptre/provider-pw/config.ini": "b2043f396a69f09e3cc58346e7a73f168fc50597040b0db228edab199d0bd6a1",
-      "sceptre/provider-pw/objects.txt": "b4ca885b13f095ed5d03c77192906bbb9b267b237abdfaca6cfed9fbdb5cc736",
+      "sceptre/provider-pw/objects.txt": "07c0fec4f15314f12e77110caafaba2768153da8cdb88af9efb26155ac2bd483",
+      "sceptre/provider-pw2/config.ini": "ecd08893debbb1b370391d577b0e3a5855871872cf547316142430e53d9ea767",
+      "sceptre/provider-pw2/objects.txt": "07c0fec4f15314f12e77110caafaba2768153da8cdb88af9efb26155ac2bd483",
       "sceptre/provider-rtds/config.ini": "5cad195ee1b8aab37b602b8a13544ac610eb5fbacc4345d9f990242fc9b12d5f",
       "sceptre/provider-rtds/rtds_config.yaml": "56cd0f1f580ddb3c5d82371e4813747c9e9e07249576c6cc8d92c928b2df60b9",
       "sceptre/provider-sim/config.ini": "25a5a8e94b02f65e2c582a3e22051bb5c9bb7d1bb960bffaaf4c2da8ae96783d",
@@ -2578,6 +2712,7 @@
       "startup/helics-broker-1-helics.sh": "0de248c2b918bbce674fe114b4d051759fe3a30116ebb5d648cfffc0428490c6",
       "startup/provider-pp-start.sh": "e868ec95b313ced8bbddb30b73cde23a966265fbb24ef34f78265297be814c10",
       "startup/provider-pw-start.ps1": "48a44e9ae3efb74ace2ccdd9267f457e7e871c7c2282bd18ecf49b3f5433f595",
+      "startup/provider-pw2-start.ps1": "48a44e9ae3efb74ace2ccdd9267f457e7e871c7c2282bd18ecf49b3f5433f595",
       "startup/provider-rtds-start.sh": "0826e4f39d5581aca2c1a0bfa584ad9eae3a095d19c59e2e5695faf47d3a8adb",
       "startup/provider-sim-start.sh": "f8d9d6638776b895686a3acd9e6d678eb8670952e80c87006ce657f8d4ac900d",
       "startup/rtu-1-start.sh": "f8c77b3f4e99563d9f2568f9edd73312aac1b49ef4c9e0a119a47b5ad656c04e",

--- a/src/python/phenix_apps/apps/sceptre/tests/test_infrastructures.py
+++ b/src/python/phenix_apps/apps/sceptre/tests/test_infrastructures.py
@@ -72,7 +72,6 @@ DEVICE_TYPES = (
 def render(infrastructure: str, device_type, protocol: str) -> str:
     """One combination's behaviour, as a single line."""
 
-    Register.reset_addresses()
     try:
         device = get_fdconfig_class(infrastructure).create_device(
             device_type, "dev-1", protocol

--- a/src/python/phenix_apps/apps/sceptre/tests/test_prestart.py
+++ b/src/python/phenix_apps/apps/sceptre/tests/test_prestart.py
@@ -296,13 +296,37 @@ class TestWritePowerObjects:
     def test_merges_hil_tags_deduplicates_and_sorts(self, sceptre_app, tmp_path):
         objects = tmp_path / "objects.txt"
         ctx = PreStart(sceptre_app)
-        ctx.objects_file_path = str(objects)
+        ctx.objects_file_paths = [str(objects)]
         ctx.power_object_list = ["gen-2", "bus-1", "gen-2"]
         ctx.hil_object_list = ["hil-9", "bus-1"]
 
         ctx.power_objects()
 
         assert objects.read_text().split("\n") == ["bus-1", "gen-2", "hil-9"]
+
+    def test_every_powerworld_provider_gets_the_objects_file(
+        self, sceptre_app, tmp_path
+    ):
+        """Two providers: both objects.txt written, hil_tags from both merged.
+
+        Previously the second provider's path and hil_tags overwrote the
+        first's, so only the last objects.txt existed and only its tags
+        survived.
+        """
+        first = tmp_path / "pw-1" / "objects.txt"
+        second = tmp_path / "pw-2" / "objects.txt"
+        first.parent.mkdir()
+        second.parent.mkdir()
+        ctx = PreStart(sceptre_app)
+        ctx.objects_file_paths = [str(first), str(second)]
+        ctx.power_object_list = ["bus-1"]
+        ctx.hil_object_list = ["hil-1", "hil-2"]
+
+        ctx.power_objects()
+
+        expected = ["bus-1", "hil-1", "hil-2"]
+        assert first.read_text().split("\n") == expected
+        assert second.read_text().split("\n") == expected
 
     def test_writes_nothing_without_a_powerworld_provider(self, sceptre_app, tmp_path):
         ctx = PreStart(sceptre_app)

--- a/src/python/phenix_apps/apps/sceptre/tests/test_sceptre_input.yaml
+++ b/src/python/phenix_apps/apps/sceptre/tests/test_sceptre_input.yaml
@@ -3,7 +3,7 @@
 # Deliberately exercises every branch that the configure and pre-start stages
 # reach, including several that only fire on odd topologies:
 #
-#   - three providers with different simulators: PowerWorld (Windows paths),
+#   - providers with different simulators: two PowerWorld (Windows paths),
 #     PyPower, and Simulink with ground truth (the solver/publish-points/gt
 #     injections, which no other host exercises)
 #   - fd-servers on both dnp3 and modbus, plus a serial interface
@@ -46,6 +46,19 @@ spec:
               hil_tags:
                 - hil-bus-9.voltage
               debug: true
+
+          # Second PowerWorld provider: pins that hil_tags aggregate across
+          # providers and that every PowerWorld provider gets an objects.txt
+          # (each used to be overwritten by the last provider seen).
+          - hostname: provider-pw2
+            metadata:
+              type: provider
+              simulator: PowerWorld
+              case: /phenix/topologies/golden/case2.PWB
+              oneline: /phenix/topologies/golden/oneline2.pwd
+              hil_tags:
+                - hil-bus-9.voltage
+                - hil-line-2.current
 
           - hostname: provider-pp
             metadata:
@@ -224,6 +237,13 @@ spec:
           interfaces:
             - {name: IF0, type: ethernet, vlan: MGMT, address: 172.16.0.10, mask: 16}
             - {name: IF1, type: ethernet, vlan: field, address: 10.2.0.10, mask: 24}
+
+      - general: {hostname: provider-pw2}
+        hardware: {os_type: windows}
+        network:
+          interfaces:
+            - {name: IF0, type: ethernet, vlan: MGMT, address: 172.16.0.14, mask: 16}
+            - {name: IF1, type: ethernet, vlan: field, address: 10.2.0.14, mask: 24}
 
       - general: {hostname: provider-pp}
         hardware: {os_type: linux}


### PR DESCRIPTION
## Description
`Register.addresses` was a class-level mutable dict reset by `FieldDeviceConfig` after building each config, so register numbering was order-dependent global state: a test raising part-way left it dirty (the suite carried an autouse reset fixture as a workaround), and parallel test runs were unsafe.

Each `FieldDeviceConfig` now owns one `addresses` dict, threaded through `Protocol` and `create_device` into `Device` and `Register`; a standalone `Device` (as the characterization test builds them) defaults to a fresh copy of `Register.START`. `reset_addresses()` and both test workarounds are deleted.

Proof nothing behavioral changed: both goldens are byte-identical, and the suite passes under `pytest-xdist -n 4`.

**Note:** stacked on #139 (rebased onto `main` after #137 and #138 merged). Merge #139 first and this shrinks to just the refactor (6 files, +34/−32).

## Related Issue
Stacked on #139.

## Type of Change
- [ ] Bugfix
- [ ] New feature
- [ ] Documentation update
- [x] Other (please describe): refactor, no output change

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.


