### PR TITLE
feat(mgmt_tap): configurable bridge, defaulting to the experiment bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ make clean       # Clean build artifacts
 | [caldera](src/python/phenix_apps/apps/caldera) | Runs operations and retrieves reports from a Caldera C2 server. |
 | [helics](src/python/phenix_apps/apps/helics) | Configures and manages HELICS (Hierarchical Engine for Large-scale Infrastructure Co-Simulation) federates. |
 | [ignition](src/python/phenix_apps/apps/ignition) | Configures an Ignition Gateway SCADA master from discovered DNP3 outstations or a hand-authored gateway backup. |
+| [mgmt_tap](src/python/phenix_apps/apps/mgmt_tap) | Creates a host tap on the experiment's management network to copy files to and from VMs. |
 | [mirror](src/go/cmd/phenix-app-mirror) | Configures cluster-wide packet mirroring to a target node using GRE or ERSPAN tunnels. |
 | [otsim](src/python/phenix_apps/apps/otsim) | Generates configuration files for OT-sim simulations. |
 | [protonuke](src/python/phenix_apps/apps/protonuke) | Injects command-line arguments for the `protonuke` agent service. |
@@ -72,6 +73,7 @@ make clean       # Clean build artifacts
 | [cc](src/python/phenix_apps/apps/scorch/cc) | Executes arbitrary shell commands on nodes via minimega's command and control. |
 | [collector](src/python/phenix_apps/apps/scorch/collector) | Collects files from specified nodes for post-experiment analysis. |
 | [disruption](src/python/phenix_apps/apps/scorch/disruption) | Simulates network disruptions like Denial of Service (DoS) attacks. |
+| [erspan](src/python/phenix_apps/apps/scorch/erspan) | Mirrors traffic from an experiment's OVS bridge to a remote capture host via ERSPAN. |
 | [ettercap](src/python/phenix_apps/apps/scorch/ettercap) | Runs the Ettercap suite for man-in-the-middle attacks. |
 | [hoststats](src/python/phenix_apps/apps/scorch/hoststats) | Collects host performance statistics (CPU, memory, etc.). |
 | [iperf](src/python/phenix_apps/apps/scorch/iperf) | Measures network performance between nodes using iperf. |
@@ -84,6 +86,7 @@ make clean       # Clean build artifacts
 | [qos](src/python/phenix_apps/apps/scorch/qos) | Applies Quality of Service (QoS) rules (e.g., latency, packet loss) to interfaces. |
 | [rtds](src/python/phenix_apps/apps/scorch/rtds) | Interacts with RTDS (Real Time Digital Simulator) systems. |
 | [snort](src/python/phenix_apps/apps/scorch/snort) | Runs the Snort Intrusion Detection System on specified interfaces. |
+| [ssh](src/python/phenix_apps/apps/scorch/ssh) | Executes commands on and copies files from a remote host over SSH. |
 | [tcpdump](src/python/phenix_apps/apps/scorch/tcpdump) | Captures network traffic using tcpdump. |
 | [trafficgen](src/python/phenix_apps/apps/scorch/trafficgen) | Generates network traffic between specified source and destination nodes. |
 | [vmstats](src/python/phenix_apps/apps/scorch/vmstats) | Collects detailed VM statistics from minimega. |

--- a/src/python/phenix_apps/apps/mgmt_tap/README.md
+++ b/src/python/phenix_apps/apps/mgmt_tap/README.md
@@ -9,6 +9,18 @@ E.g.
 ```yaml
 - name: mgmt_tap
   metadata:
-subnet: 172.16.0.0/16
-vlan: MGMT_1
+    subnet: 172.16.0.0/16
+    vlan: MGMT_1
+    bridge: phenix
 ```
+
+## Metadata
+
+| Key      | Required | Default                                   | Description                                        |
+| -------- | -------- | ----------------------------------------- | -------------------------------------------------- |
+| `subnet` | no       | `172.16.0.0/16`                           | Subnet used to address the host taps.               |
+| `vlan`   | no       | `MGMT`                                    | VLAN alias the tap is attached to.                  |
+| `bridge` | no       | experiment `spec.defaultBridge` (`phenix`) | OVS bridge the host tap is created on.              |
+
+If `bridge` is not set, the app uses the experiment's `spec.defaultBridge`.
+If the experiment does not define one, it falls back to `phenix`.

--- a/src/python/phenix_apps/apps/mgmt_tap/app.py
+++ b/src/python/phenix_apps/apps/mgmt_tap/app.py
@@ -21,13 +21,18 @@ class MgmtTap(AppBase):
           metadata:
             subnet: 172.16.0.0/16
             vlan: MGMT_1
+            bridge: phenix
     """
+
+    DEFAULT_BRIDGE = "phenix"
 
     def __init__(self, name: str, stage: str, dryrun: bool = False) -> None:
         super().__init__(name, stage, dryrun)
         # Check if subnet and namespace is specified in app metadata
         self.subnet = self.metadata.get("subnet", None) if self.metadata else None
         self.vlan = self.metadata.get("vlan", "MGMT") if self.metadata else "MGMT"
+        # Bridge from app metadata, falling back to the experiment default bridge
+        self.bridge = self._get_bridge()
         # Must limit the tap_name to 14 characters. minimega won't create the host taps otherwise
         self.exp_name = self.exp_name[:9]
         self.vlan_name = self.exp_name[:4]
@@ -40,6 +45,27 @@ class MgmtTap(AppBase):
             logger.error("No hosts found in 'mgmt_tap' application!")
             raise RuntimeError("No hosts found in mgmt_tap application")
         self.hostname = socket.gethostname().split("-")[0]
+
+    def _get_bridge(self) -> str:
+        """Determine which OVS bridge the tap should be created on.
+
+        Priority:
+            1. ``bridge`` key in the app metadata
+            2. The experiment's ``spec.defaultBridge``
+            3. ``phenix`` (the phenix built-in default)
+        """
+        bridge = self.metadata.get("bridge", None) if self.metadata else None
+        if bridge:
+            logger.debug(f"Using bridge '{bridge}' from app metadata")
+            return bridge
+
+        bridge = self.experiment.spec.get("defaultBridge", None)
+        if bridge:
+            logger.debug(f"Using experiment default bridge '{bridge}'")
+            return bridge
+
+        logger.debug(f"Falling back to bridge '{self.DEFAULT_BRIDGE}'")
+        return self.DEFAULT_BRIDGE
 
     def _get_mm_connection(self) -> minimega.minimega:
         """Get or create minimega connection."""
@@ -82,12 +108,12 @@ class MgmtTap(AppBase):
                 raise RuntimeError("Ran out of IP addresses on host") from err
 
             ip_ = f"{ip_addr}/{network.prefixlen}"
-            logger.debug(f"Creating host tap {ip_} on {host}")
+            logger.debug(f"Creating host tap {ip_} on {host} (bridge: {self.bridge})")
             kwargs = {
                 "experiment": self.exp_name,
                 "computes": host,
                 "command_type": "tap",
-                "command": f"create {vlan} bridge phenix ip {ip_} {self.tap}",
+                "command": f"create {vlan} bridge {self.bridge} ip {ip_} {self.tap}",
                 "ignore_error": True,
             }
             mm_obj = self._get_mm_connection()

--- a/src/python/phenix_apps/apps/mgmt_tap/tests/test_mgmt_tap.py
+++ b/src/python/phenix_apps/apps/mgmt_tap/tests/test_mgmt_tap.py
@@ -1,0 +1,72 @@
+"""Unit tests for the mgmt_tap app."""
+
+import pytest
+from box import Box
+
+from phenix_apps.apps.mgmt_tap.app import MgmtTap
+
+pytestmark = pytest.mark.app_class(cls=MgmtTap, name="mgmt_tap")
+
+
+def _configure(mock_app, metadata=None, spec=None):
+    """Set the metadata / experiment spec that _get_bridge() reads."""
+    mock_app.metadata = metadata if metadata is None else Box(metadata)
+    mock_app.experiment = Box({"spec": spec or {}})
+    return mock_app
+
+
+# --- Bridge resolution -------------------------------------------------------
+
+
+def test_metadata_bridge_takes_precedence(mock_app):
+    """An explicit bridge in app metadata wins over the experiment default."""
+    app = _configure(mock_app, {"bridge": "metabr"}, {"defaultBridge": "expbr"})
+    assert app._get_bridge() == "metabr"
+
+
+def test_falls_back_to_experiment_default_bridge(mock_app):
+    """With no metadata bridge, the experiment's defaultBridge is used."""
+    app = _configure(mock_app, {}, {"defaultBridge": "expbr"})
+    assert app._get_bridge() == "expbr"
+
+
+def test_falls_back_to_phenix_when_no_default_bridge(mock_app):
+    """Neither metadata nor spec set a bridge, so the built-in default applies."""
+    app = _configure(mock_app, {}, {})
+    assert app._get_bridge() == MgmtTap.DEFAULT_BRIDGE == "phenix"
+
+
+@pytest.mark.parametrize("empty", ["", None])
+def test_empty_metadata_bridge_is_ignored(mock_app, empty):
+    """A blank bridge value must not shadow the experiment default."""
+    app = _configure(mock_app, {"bridge": empty}, {"defaultBridge": "expbr"})
+    assert app._get_bridge() == "expbr"
+
+
+def test_absent_metadata_is_tolerated(mock_app):
+    """metadata may be None/empty; resolution must not raise."""
+    app = _configure(mock_app, None, {"defaultBridge": "expbr"})
+    assert app._get_bridge() == "expbr"
+
+
+# --- Bridge is threaded into the minimega command ----------------------------
+
+
+def test_post_start_uses_resolved_bridge(mock_app, mocker):
+    """The resolved bridge is what actually lands in the `tap create` command."""
+    app = _configure(mock_app, {"bridge": "metabr"}, {"defaultBridge": "expbr"})
+    app.bridge = app._get_bridge()
+    app.vlan = "MGMT"
+    app.subnet = None
+    app.tap = "testexp_test"
+    app.hosts = ["host1"]
+    app.experiment.status = Box({"vlans": {"MGMT": 101}})
+
+    mocker.patch.object(MgmtTap, "_get_mm_connection", return_value=mocker.MagicMock())
+    compute_cmd = mocker.patch("phenix_apps.apps.mgmt_tap.app.mm_compute_cmd")
+
+    app.post_start()
+
+    command = compute_cmd.call_args.kwargs["command"]
+    assert "bridge metabr" in command
+    assert "bridge phenix" not in command

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "elasticsearch<9",
     "kafka-python~=2.2.13",
-    "lxml~=4.9.2",
+    "lxml>=4.9.2",
     "Mako~=1.1.3",
     "minimega",
     "loguru>=0.7.2",


### PR DESCRIPTION
# feat(mgmt_tap): configurable bridge, defaulting to the experiment bridge

## Description

`mgmt_tap` created its host tap on a hardcoded `phenix` bridge:

```python
"command": f"create {vlan} bridge phenix ip {ip_} {self.tap}",
```

Any experiment created with a non-default bridge (`phenix create --default-bridge ...`, or a workflow setting `defaultBridge`) therefore got its management tap attached to a bridge the experiment does not use, leaving the tap unable to reach the VMs.

This PR makes the bridge configurable and, when unset, inherits it from the experiment.

**Bridge resolution order**

1. `bridge` key in the app metadata — explicit override
2. The experiment's `spec.defaultBridge` — the new default behaviour
3. `"phenix"` — final guard

Tier 3 is deliberately redundant: phenix core populates `defaultBridge` during experiment init and self-defaults it to `phenix` ([`types/version/v1/experiment.go`](https://github.com/sandialabs/sceptre-phenix/blob/main/src/go/types/version/v1/experiment.go)), so tier 2 normally answers. It is kept for hand-constructed or dry-run payloads that skip that init. This mirrors the fallback the Go `mirror` app already uses (`exp.Spec.DefaultBridge()`).

Usage:

```yaml
- name: mgmt_tap
  metadata:
    subnet: 172.16.0.0/16
    vlan: MGMT_1
    bridge: my-bridge   # optional; defaults to the experiment's bridge
```

**Also included**

- Test suite for `mgmt_tap` (7 tests) — the app previously had none.
- Top-level `README.md`: adds the missing `mgmt_tap` entry. An audit of the tables against the source tree turned up two further omissions, the `erspan` and `ssh` Scorch components, so those are added too.
- `src/python/phenix_apps/apps/mgmt_tap/README.md`: documents the `bridge` key, adds a metadata table, and fixes the broken YAML indentation in the existing example.
- `pyproject.toml`: relaxes the `lxml` pin from `~=4.9.2` to `>=4.9.2`; the strict pin does not build on Python 3.13+.

## Related Issue

N/A

## Type of Change

Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [x] Documentation update
- [x] Other (please describe): adds a test suite for an app that had none; relaxes the `lxml` version pin

## Checklist

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

Live tested by running an experiment with a default bridge that was not `phenix`
